### PR TITLE
masks fuse into formulas, coercion stops lying: the break-pass sweep

### DIFF
--- a/FAILURES.md
+++ b/FAILURES.md
@@ -1,0 +1,44 @@
+# Coercion break-pass — failure list (lifting only, no fixes)
+~200 adversarial cases, 6 rounds. Verified formulas track perturbed inputs in 24/25 spot checks.
+Scripts: /tmp/break/round{1..6}.py (repro: run any with the scipy-dev python)
+
+## A. SILENT-WRONG (value or formula lies — worst class)
+1. np.add.at(y, [0,0], 1.0)   -> silently NO-OPS on a traced array (got 1.5, expect 3.5)
+2. np.place(y, y<0, [0.0])    -> silently NO-OPS (got 3.25, expect 5.25)
+3. np.nan_to_num(x/0.0)       -> inf NOT clamped: value lane -inf vs numpy's ±1.798e308
+4. pandas Series(x).sum()     -> returns the full array instead of the scalar sum
+5. int scalar input: to_sympy(lambda a: a+1, 3) -> formula "4", input symbol dropped
+   (float scalar input correctly gives a+1; only python ints collapse)
+6. nditer over object array   -> runs but formula constant
+
+## B. DIED (should refuse loudly or work)
+7.  round(pair, n) / round(pair)      TypeError: no __round__
+8.  divmod(pair, 2.0)                 TypeError
+9.  f"{pair:.2f}" / format(pair)      TypeError: unsupported format string
+10. float(str(pair))                  ValueError (repr leaks "Pair(x[0])")
+11. np.interp(t, xs, ys) traced xs    TypeError: cannot cast dtype('O')
+12. np.corrcoef(x, x[::-1])           TypeError: scalar Pair not subscriptable
+13. np.cov(x)                         ValueError: unpack
+14. pair // 2.0 (floor div)           TypeError: no __floordiv__
+15. np.select([conds],[choices])      TypeError: condlist must be bool ndarray
+16. np.linalg.inv / eigvals on Pair   AttributeError: no __array_wrap__
+17. np.putmask(pair, ...)             TypeError: first arg must be array
+18. np.copyto(y, pair)                TypeError
+19. pair.fill(2.0)                    AttributeError: no fill
+20. pair.tolist()                     AttributeError: no tolist
+21. scipy.stats.iqr(x)                ValueError: broadcast remap
+22. varargs signature def f(*arrs)    TypeError: takes 1 arguments, got 2 (api wrapper)
+
+## C. Loud refusals — correct behavior, listed for coverage review
+- np.round (math-changing: right), np.piecewise (bool coercion), np.histogram(raw operand msg misleads: input WAS wrapped)
+- ufunc.accumulate / .outer / .reduceat / out= / frexp / modf (2-output)
+- astype(str), structured arrays (fancy indexing msg misleading)
+- pandas DataFrame ops (data-dependent branch)
+- chained float() in user code (right; message good)
+
+## D. Notes / oddities (not failures, worth eyes)
+- weighted_mean formula contains disclosed const_0 table -> substitution needs table values (by design)
+- np.sort(x)[1] etc: all ordering-guard paths verified correct incl. preconditions gating
+- empty array: Sum(a[j], (j,0,-1)) — correct empty-sum convention, prints oddly
+- f(x, x) same array twice -> named a and b independently (defensible; loses aliasing info)
+- kwarg scalars become symbols (scale*a[i]) — nice, but means kwargs are never constant-folded

--- a/LOOP_DOMAINS.md
+++ b/LOOP_DOMAINS.md
@@ -1,0 +1,103 @@
+# Loops as domains
+
+A loop is an axis in time. Array axes are already domains: `x[i]` with
+bounds, bound by `Sum(..., (i, 0, n-1))`. An iteration index `k` is the
+same object, bound by a recurrence instead of a reduction. Today the
+tracer unrolls loops into the live formula, so iterative solvers
+(BayesianRidge: 300 iterations, each formula containing the last)
+snowball and never finish. Folding exists (`_fold_runs`,
+`derivation()`) but runs post-hoc on `.steps` -- downstream of the
+blowup. This note moves the fold into the formula lane itself.
+
+Everything below is explicitly sympy: `subs`, `doit`, `lambdify`,
+`free_symbols` work on the certificate with no side-channel records.
+All claims execution-verified on sympy 1.14.
+
+## The three tiers
+
+| loop shape | sympy object | verified behavior |
+|---|---|---|
+| accumulator `t += x[k]` | `Sum` / `Product` | already emitted for np.sum; hand loops should reach it |
+| linear scalar recurrence | `rsolve` -> closed expression | `rsolve(C(k+1)-2C(k)-1, C(k), {C(0):1})` -> `2**(k+1)-1` |
+| linear VECTOR recurrence | `MatPow`: `C[k] = A**k * C[0]` | `(A**k).doit()` diagonalizes symbolically; `subs(k,3)` exact |
+| general scalar recurrence | `RecursiveSeq` | Basic; `subs` traverses; `.coeff(k)` unrolls lazily |
+| general vector / coupled | custom `Iterate` Function (below) | held form, lazy unroll, Tuple state |
+
+## Verified capabilities and limits
+
+RecursiveSeq (sympy.series.sequences):
+- IS `Basic`; `free_symbols` correct; symbolic parameters in the body
+  survive (`coeff(3)` of `y=2y+a` -> `7*a + 8`); `subs` composes.
+- Scalar ONLY: Matrix and MatrixSymbol terms fail (AttributeError /
+  ShapeError). Tuple packing fails. A second Function in the body
+  stays unresolved (`z(0), z(1)` free) -- no coupled systems.
+
+MatPow:
+- `A**k` with symbolic integer `k` is native, `.doit()` produces the
+  closed form via diagonalization, exact under `subs(k, n)`.
+- Covers every CONSTANT-coefficient linear vector recurrence.
+
+Iterate (ours, ~10 lines):
+```python
+class Iterate(sympy.Function):
+    """Iterate(step, init, k): k-fold application of step to init."""
+    @classmethod
+    def eval(cls, step, init, k):
+        if k.is_Integer and k >= 0:
+            out = init
+            for _ in range(int(k)):
+                out = step(*out) if isinstance(out, sympy.Tuple) else step(out)
+            return out
+```
+- Held while `k` is symbolic: `Iterate(Lambda(c, 2c+a), 1, K)`,
+  free symbols `{a, K}`. `subs(K, 3)` unrolls on demand -> `7*a + 8`;
+  after full substitution it is a number (lambdify-able).
+- Vector and COUPLED state as one `Tuple`:
+  `Iterate(Lambda((c1,c2), Tuple(c1+c2, c1*a)), Tuple(1,2), K)`
+  -> `subs(K,2)` -> `(a+3, 3*a)`. This is the BayesianRidge shape
+  (coef and alpha updating each other).
+- A subclass of `sympy.Function` IS sympy: printing, traversal,
+  substitution all come from Basic. No metadata channel.
+
+## Trace-time mechanics
+
+The hooks exist. The rewriter already tags every loop
+(`__skv_loop_iter__` / `__skv_loop_end__`, `session.loop_events`), so
+Pairs are attributable to (loop, iteration) DURING the trace.
+
+1. Run iteration 0 and 1 concretely, formulas eager (today's path).
+2. At iteration 1's end, attempt the fold: do iteration 1's formulas
+   equal iteration 0's under a template with the loop-carried state
+   replaced by a state symbol? This is `_generalize`'s check, applied
+   live. Multiple carried variables pack into one Tuple state.
+3. Fold succeeds: replace the carried Pairs' formulas with the tier
+   object (Sum/rsolve/MatPow/RecursiveSeq/Iterate) and run remaining
+   iterations on the VALUE LANE ONLY, verifying each iteration's
+   concrete values against the template (the per-iteration residual --
+   same role contracts play for atoms). Formula size is now
+   O(template), independent of iteration count.
+4. Fold fails (body not one template -- data-dependent branch inside):
+   keep today's unrolling, with a formula-size budget that refuses
+   loudly instead of hanging.
+
+Data-dependent exits (`while not converged`) are already guards: the
+stopping condition's `__bool__` records the path. `K = 17` enters the
+formula as a concrete bound with the convergence guard in
+preconditions, exactly like searchsorted's counting bound.
+
+## Verification story
+
+- Tier objects evaluate: `.coeff(k)` / `subs(K, k)` reproduce the
+  unrolled formula for any k, so the two-lane fuzzer applies directly.
+- Per-iteration residual at trace time: template instantiated with
+  iteration k's concrete state must equal iteration k+1's concrete
+  state. 300 cheap numeric checks replace one 300-deep expression.
+
+## Refusals (loud, by construction)
+
+- Loop body changes shape between iterations (branch taken differently)
+  and sizes exceed the budget -> "iterative body is not one template".
+- `rsolve` fails and the recurrence is nonlinear scalar -> RecursiveSeq
+  (still exact); vector -> Iterate (still exact). Refusal is only for
+  non-foldable bodies, never for "no closed form" -- a held recurrence
+  IS an exact formula.

--- a/skverify/api.py
+++ b/skverify/api.py
@@ -28,6 +28,9 @@ def to_sympy(fn, *args, **kwargs):
     if sys.getrecursionlimit() < 20000:
         sys.setrecursionlimit(20000)
 
+    _session.reset()
+    # reset FIRST: _wrap records disclosures (integer-as-config) into
+    # the session, and they must survive to the harvest
     if kwargs:
         # keyword arguments wrap by their own names
         args = args + tuple(kwargs.values())
@@ -38,7 +41,6 @@ def to_sympy(fn, *args, **kwargs):
         _wrap(name, val)
         for name, val in _infer_names(fn, args[: len(args) - len(kw_wrapped)])
     ]
-    _session.reset()
     sites = ()
     try:
         out = _repack(fn(*wrapped, **kw_wrapped))
@@ -81,6 +83,11 @@ def to_sympy(fn, *args, **kwargs):
         # formula holds for inputs satisfying these preconditions.
         # Attached to whatever came back -- a Pair, or a library object
         # (BSpline) whose attributes carry the traced Pairs
+        for pending in _session.pending_mask_guards.values():
+            # gathers no reduction fused: their selection facts are
+            # preconditions after all
+            _GUARDS.extend(pending)
+        _session.pending_mask_guards.clear()
         out.preconditions = sympy.And(*_GUARDS) if _GUARDS else sympy.true
         records = list(_OPAQUE)
         if _session.hashed:
@@ -102,8 +109,24 @@ def to_sympy(fn, *args, **kwargs):
 
 
 def _wrap(name, val):
-    if val is None or isinstance(val, (bool, np.bool_, int, np.integer, str)):
-        return val  # config, not math: np.diff(a, 2) keeps its plain 2
+    if val is None or isinstance(val, (bool, np.bool_, str)):
+        return val
+    if isinstance(val, (int, np.integer)):
+        # config, not math: np.diff(a, 2) keeps its plain 2. But the
+        # assumption must be DISCLOSED -- an integer that was really
+        # data would otherwise certify a constant silently
+        _session.opaque.append(
+            (
+                f"arg:{name}",
+                (("integer argument", "traced as constant"),),
+                (
+                    f"{name} = {val}",
+                    "integers are treated as configuration; pass a "
+                    "float to trace symbolically",
+                ),
+            )
+        )
+        return val
     if np.isscalar(val):
         return Pair(val, sympy.Symbol(name, real=True))
     if hasattr(val, "to_numpy") and not isinstance(val, np.ndarray):
@@ -324,7 +347,14 @@ def _recompress(formulas):
 
 def _infer_names(fn, args):
     """Pair each positional argument with its parameter name from fn's signature."""
-    names = list(inspect.signature(fn).parameters)
+    params = inspect.signature(fn).parameters
+    names = []
+    for name, p in params.items():
+        if p.kind is inspect.Parameter.VAR_POSITIONAL:
+            # *args: one name per remaining argument
+            names.extend(f"{name}{k}" for k in range(len(args) - len(names)))
+            break
+        names.append(name)
     if len(args) > len(names):
         raise TypeError(f"{fn.__name__} takes {len(names)} arguments, got {len(args)}")
     return zip(names, args)

--- a/skverify/atoms.py
+++ b/skverify/atoms.py
@@ -12,7 +12,7 @@ scribbled on traced inputs.
 import numpy as np
 import sympy
 
-from .coercion import formula_of, value_of
+from .coercion import value_of
 from .helpers import axis_idx
 from .session import current as _session
 

--- a/skverify/coercion.py
+++ b/skverify/coercion.py
@@ -135,6 +135,49 @@ def formula_of(x):
     return sympy.sympify(x)
 
 
+def repack(x):
+    """One indexed Pair from a decompressed object array, or None.
+
+    The inverse of decompression: when every element is a Pair and the
+    element formulas share one provable pattern, the array becomes a
+    single Pair carrying the recompressed indexed formula. Boundaries
+    that need whole-array semantics (method-call reductions, compiled
+    entries) try this FIRST -- succeeding keeps every downstream
+    mechanism on the strong, indexed path.
+
+    Parameters
+    ----------
+    x : ndarray
+        Candidate object array.
+
+    Returns
+    -------
+    Pair or None
+        The repacked Pair, or None when no exact pattern exists
+        (callers fall back to their own handling; refusal stays THEIR
+        contract, not this helper's).
+    """
+    from .pair import Pair
+
+    if not (
+        isinstance(x, np.ndarray)
+        and x.dtype == object
+        and x.size
+        and all(isinstance(e, Pair) for e in x.ravel())
+    ):
+        return None
+    try:
+        formula = formula_of(x)
+    except NotImplementedError:
+        return None
+    return Pair(
+        value_of(x),
+        formula,
+        tuple((0, int(n)) for n in x.shape),
+        steps=tuple(x.ravel()),
+    )
+
+
 def numeric(v, copy=True):
     """Real float array from a plain-number object array.
 

--- a/skverify/contracts.py
+++ b/skverify/contracts.py
@@ -151,6 +151,28 @@ CONTRACTS = {
         "law": "A @ v == w * v",
         "residual": None,
     },
+    "inv": {
+        "requires": [],
+        "law": "A @ inv(A) == I",
+        "residual": lambda args, out: (
+            "ok"
+            if np.allclose(np.asarray(args[0]) @ np.asarray(out), np.eye(len(out)))
+            else "failed"
+        ),
+    },
+    "eigvals": {
+        "requires": [],
+        "law": "det(A - w*I) == 0 for every eigenvalue w",
+        "residual": lambda args, out: (
+            "ok"
+            if all(
+                abs(np.linalg.det(np.asarray(args[0], dtype=complex) - w * np.eye(len(args[0]))))
+                < 1e-6 * max(1.0, abs(np.linalg.det(np.asarray(args[0], dtype=complex))))
+                for w in np.atleast_1d(out)
+            )
+            else "failed"
+        ),
+    },
 }
 
 

--- a/skverify/instrument/registries.py
+++ b/skverify/instrument/registries.py
@@ -14,6 +14,9 @@ NEUTRAL = {
     "ascontiguousarray",
     "asfortranarray",
     "asarray_chkfinite",
+    # identity on valid input like the asarray family; the dtype/order
+    # requirements are memory bookkeeping, not math
+    "require",
 }
 OPAQUE_CALLABLES = {
     "solve_banded",

--- a/skverify/instrument/rewriter.py
+++ b/skverify/instrument/rewriter.py
@@ -21,6 +21,51 @@ from .registries import (
 )
 
 class _Rewriter(ast.NodeTransformer):
+    def visit_Subscript(self, node):
+        self.generic_visit(node)
+        # only simple-expression indices in Load position: slices keep
+        # native syntax, stores keep assignment semantics
+        if isinstance(node.ctx, ast.Load) and not isinstance(
+            node.slice, (ast.Slice, ast.Tuple)
+        ):
+            return ast.Call(
+                func=ast.Name(id="__skv_getitem__", ctx=ast.Load()),
+                args=[node.value, node.slice],
+                keywords=[],
+            )
+        return node
+
+    def visit_Compare(self, node):
+        self.generic_visit(node)
+        # numpy collapses elementwise comparison of object arrays to a
+        # concrete bool array (each Pair's condition is bool()ed away);
+        # route single comparisons through a runtime helper that keeps
+        # the conditions when Pairs are inside
+        simple = {
+            ast.Eq: "eq", ast.NotEq: "ne", ast.Lt: "lt",
+            ast.LtE: "le", ast.Gt: "gt", ast.GtE: "ge",
+        }
+        if len(node.ops) == 1 and type(node.ops[0]) in simple:
+            return ast.Call(
+                func=ast.Name(id="__skv_cmp__", ctx=ast.Load()),
+                args=[
+                    ast.Constant(value=simple[type(node.ops[0])]),
+                    node.left,
+                    node.comparators[0],
+                ],
+                keywords=[],
+            )
+        return node
+
+    def visit_DictComp(self, node):
+        self.generic_visit(node)
+        self.sites.append("dict comprehension -> selection-preserving")
+        return ast.Call(
+            func=ast.Name(id="__skv_dict__", ctx=ast.Load()),
+            args=[node],
+            keywords=[],
+        )
+
     def __init__(self, fn_globals, tag=""):
         self.fn_globals = fn_globals
         self.tag = tag
@@ -129,7 +174,17 @@ class _Rewriter(ast.NodeTransformer):
                 self.sites.append(f"{ref} (reference) -> pair-preserving")
                 node.args[pos] = ast.Name(id="__skv_neutral__", ctx=ast.Load())
         name = self._target_name(node.func)
-        if name in ALLOC:
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "float"
+            and len(node.args) == 1
+            and not node.keywords
+        ):
+            # float() forces __float__, which must return a real float:
+            # the one cast a Pair cannot survive. In the twin,
+            # float(pair) keeps the pair (its value lane IS the float)
+            node.func = ast.Name(id="__skv_float__", ctx=ast.Load())
+        elif name in ALLOC:
             self.sites.append(f"{name} -> traced allocation")
             node.func = ast.Name(id=f"__skv_{name}__", ctx=ast.Load())
         elif name in NEUTRAL:
@@ -142,6 +197,9 @@ class _Rewriter(ast.NodeTransformer):
                 args=[ast.Constant(value=name)] + node.args,
                 keywords=node.keywords,
             )
+        elif name == "dict" and isinstance(node.func, ast.Name) and len(node.args) == 1:
+            self.sites.append("dict -> selection-preserving")
+            node.func = ast.Name(id="__skv_dict__", ctx=ast.Load())
         elif name == "set" and isinstance(node.func, ast.Name) and len(node.args) <= 1:
             self.sites.append("set -> guarded dedup")
             node.func = ast.Name(id="__skv_set__", ctx=ast.Load())

--- a/skverify/instrument/runtime.py
+++ b/skverify/instrument/runtime.py
@@ -14,6 +14,8 @@ touched.
 
 import inspect
 
+import operator
+
 import numpy as np
 import sympy
 
@@ -37,12 +39,18 @@ def _skv_ones(shape, dtype=None, *args, **kwargs):
     return Pair(np.ones(shape, dtype=dtype), sympy.Integer(1), _bounds_of(shape))
 
 
-def _skv_full(shape, fill, dtype=None, *args, **kwargs):
+def _skv_full(shape, fill_value, dtype=None, *args, **kwargs):
+    # parameter names mirror np.full: callers pass fill_value by keyword
+    if not isinstance(fill_value, Pair):
+        # a concrete fill stays a concrete buffer: lifting it would pin
+        # a formula that later compiled writes (np.place, putmask)
+        # cannot update -- correct value lane, silently wrong formula
+        return np.full(shape, fill_value, dtype=dtype)
     return Pair(
-        np.full(shape, Pair._value_of(fill)),
-        Pair._formula_of(fill),
+        np.full(shape, Pair._value_of(fill_value), dtype=dtype),
+        Pair._formula_of(fill_value),
         _bounds_of(shape),
-        steps=Pair._steps_of(fill),
+        steps=Pair._steps_of(fill_value),
     )
 
 
@@ -91,6 +99,23 @@ def _skv_method(name, obj, *args, **kwargs):
     ):
         if name in ("astype", "copy"):
             return obj  # traced scalars; the cast/copy is math-neutral
+        from ..coercion import repack
+
+        from .triage import _BAG_REDUCTIONS
+
+        rp = repack(obj) if name in _BAG_REDUCTIONS else None
+        np_fn = getattr(np, name, None) if name in _BAG_REDUCTIONS else None
+        if rp is not None and callable(np_fn):
+            # a provable pattern: back on the indexed path, where the
+            # dispatch protocol routes to the registered entry
+            return np_fn(rp, *args, **kwargs)
+        from ..registry import FUNCTION_TABLE
+
+        entry = FUNCTION_TABLE.get(np_fn)
+        if entry is not None:
+            # no pattern (a permuted bag): the registered entry works
+            # elementwise from the object array
+            return entry(obj, *args, **kwargs)
     if not isinstance(obj, Pair):
         if (
             isinstance(obj, np.ndarray)
@@ -159,6 +184,23 @@ class _SkvAt:
 
 
 def _skv_at(real_at, x, *args, **kwargs):
+    # two callables share the name: ufunc.at (in-place, duplicate
+    # indices accumulate) and array_api_extra's functional at(x, idx)
+    if isinstance(getattr(real_at, "__self__", None), np.ufunc):
+        ufunc = real_at.__self__
+        if not isinstance(x, Pair):
+            return real_at(x, *args, **kwargs)
+        idx = np.ravel(np.asarray(args[0]))
+        if len(args) > 1:
+            vals = np.broadcast_to(np.asarray(args[1]), idx.shape)
+            # sequential per-position updates: exactly ufunc.at's
+            # accumulation semantics, on both lanes via Pair setitem
+            for i, v in zip(idx.tolist(), vals.tolist()):
+                x[int(i)] = ufunc(x[int(i)], v)
+        else:
+            for i in idx.tolist():
+                x[int(i)] = ufunc(x[int(i)])
+        return None
     # array_api_extra's functional update: on a Pair it is setitem on
     # a copy; anything else goes to the real helper
     if isinstance(x, Pair):
@@ -203,6 +245,138 @@ def _skv_set(iterable=()):
     from ..sets import TracedSet
 
     return TracedSet(items)
+
+
+class MaskedElems(np.ndarray):
+    """Survivors of a bag-form mask gather, carrying provenance.
+
+    ``skv_pairs`` holds (element, condition) for EVERY original
+    position; reductions fuse the conditions into their formulas
+    instead of needing per-position guards.
+    """
+
+    def __array_finalize__(self, obj):
+        self.skv_pairs = getattr(obj, "skv_pairs", None)
+
+
+_CMP_OPS = {
+    "eq": operator.eq, "ne": operator.ne, "lt": operator.lt,
+    "le": operator.le, "gt": operator.gt, "ge": operator.ge,
+}
+
+
+def _skv_cmp(op, left, right):
+    """Comparison that survives object arrays of Pairs.
+
+    Plain operands compare natively. When either side is an object
+    array holding Pairs, numpy would bool() each element's condition
+    away; instead compare elementwise and keep the condition Pairs.
+    """
+    def bag(x):
+        return (
+            isinstance(x, np.ndarray)
+            and x.dtype == object
+            and any(isinstance(e, Pair) for e in x.ravel())
+        )
+
+    if bag(left) or bag(right):
+        from ..coercion import value_of
+
+        l = np.asarray(left, dtype=object)
+        r = np.asarray(right, dtype=object)
+        l, r = np.broadcast_arrays(l, r)
+        conds = np.empty(l.shape, dtype=object)
+        truths = np.empty(l.shape, dtype=bool)
+        f = _CMP_OPS[op]
+        for idx in np.ndindex(l.shape):
+            c = f(l[idx], r[idx])
+            conds[idx] = c
+            truths[idx] = bool(value_of(c))
+        # concrete bool lane keeps every downstream numpy op working;
+        # the conditions ride along for gather sites that can use them
+        out = truths.view(MaskedElems)
+        out.skv_pairs = tuple(conds.ravel())
+        return out
+    return _CMP_OPS[op](left, right)
+
+
+def _skv_float(x):
+    """float() that keeps a traced scalar traced."""
+    if isinstance(x, Pair):
+        return Pair(float(np.asarray(x.value).item()), x.formula, None, steps=(x,))
+    if isinstance(x, np.ndarray) and x.size == 1:
+        e = x.ravel()[0]
+        if isinstance(e, Pair):
+            return _skv_float(e)
+        # numpy 2 forbids float() on size-1 arrays; traced shims can
+        # produce (1,) where numpy gives 0-d, so unwrap explicitly
+        return float(np.asarray(e).item())
+    return float(x)
+
+
+def _skv_getitem(obj, key):
+    """Subscript with selection semantics for traced keys.
+
+    A mapping looked up by a traced scalar is a SELECTION: the result
+    carries the Piecewise over the table. Everything else (arrays,
+    lists, plain keys) subscripts normally.
+    """
+    import collections.abc
+
+    if (
+        isinstance(obj, np.ndarray)
+        and obj.dtype == object
+        and isinstance(key, np.ndarray)
+        and key.shape == obj.shape
+        and getattr(key, "skv_pairs", None) is not None
+    ):
+        # bag-form mask gather: y[m] where m is a concrete bool mask
+        # still carrying its per-position condition Pairs. Select by
+        # the truths, keep (element, condition) provenance so a later
+        # reduction can fuse the conditions into its formula
+        truths = np.asarray(key, dtype=bool).ravel()
+        survivors = np.asarray(obj.ravel())[truths]
+        out = np.empty(len(survivors), dtype=object).view(MaskedElems)
+        for jj, e in enumerate(survivors):
+            out[jj] = e
+        out.skv_pairs = tuple(zip(obj.ravel(), key.skv_pairs))
+        return out
+    if isinstance(key, Pair) and isinstance(obj, collections.abc.Mapping):
+        import sympy
+
+        from ..coercion import formula_of, value_of
+
+        v = key.value.item() if hasattr(key.value, "item") else key.value
+        stored = obj[v]
+        pieces = []
+        for k, val in obj.items():
+            if isinstance(val, Pair) or isinstance(k, Pair):
+                k = value_of(k)
+                val_f = formula_of(val)
+            else:
+                val_f = formula_of(val)
+            pieces.append((val_f, sympy.Eq(key.formula, formula_of(k))))
+        formula = sympy.Piecewise(*pieces, (sympy.Symbol("NaN", real=True), True))
+        return Pair(
+            value_of(stored) if isinstance(stored, Pair) else stored,
+            formula,
+            None,
+            steps=(key,),
+        )
+    return obj[key]
+
+
+def _skv_dict(mapping):
+    """Guarded dict: traced keys anywhere make it a TracedDict, whose
+    lookups by traced keys return Piecewise selections."""
+    items = dict(mapping)
+    if any(isinstance(k, Pair) for k in items) or True:
+        # keys may be concrete while LOOKUPS are traced; a TracedDict
+        # costs nothing and preserves selection formulas either way
+        from ..sets import TracedDict
+
+        return TracedDict(items)
+    return items
 
 
 def _skv_isinstance(obj, types):

--- a/skverify/instrument/triage.py
+++ b/skverify/instrument/triage.py
@@ -19,6 +19,10 @@ from ..pair import Pair
 from ..session import current as _session
 from .registries import CONCRETE_BY_NAME, OPAQUE_CALLABLES
 
+# ndarray methods whose signature matches their np.* function: only
+# these may route a decompressed array through the function's entry
+_BAG_REDUCTIONS = {"mean", "sum", "prod", "min", "max", "median", "var", "std", "ptp"}
+
 # The instrumented-function cache is the session's (blank per trace).
 _FN_MEMO = _session.fn_twins
 
@@ -76,6 +80,24 @@ def _skv_maybe(fn):
             return fn(*vals, **kwargs)
 
         return concrete_inventory
+    self_arr = getattr(fn, "__self__", None)
+    if (
+        isinstance(self_arr, np.ndarray)
+        and self_arr.dtype == object
+        and getattr(fn, "__name__", None) in _BAG_REDUCTIONS
+        and any(isinstance(e, Pair) for e in self_arr.ravel())
+    ):
+        # a bound ndarray method on a decompressed traced array: the
+        # traced data is __self__, invisible to argument checks. Route
+        # through the method twin, which repacks when a pattern exists
+        from .runtime import _skv_method
+
+        name = fn.__name__
+
+        def bag_method(*args, **kwargs):
+            return _skv_method(name, self_arr, *args, **kwargs)
+
+        return bag_method
     if inspect.isbuiltin(fn) and not isinstance(
         getattr(fn, "__self__", None), (np.ndarray, Pair, type(np))
     ):
@@ -119,15 +141,17 @@ def _skv_maybe(fn):
                 wrapper = fn
 
                 def peeled(*args, **kwargs):
-                    # some wrappers INJECT arguments (sklearn's device
-                    # shims pass xp): a signature mismatch on the
-                    # peeled inner means the wrapper was load-bearing;
-                    # fall back to it untouched
+                    # some wrappers INJECT arguments into the
+                    # inner call: a signature mismatch on the peeled
+                    # inner means the wrapper was load-bearing; fall
+                    # back to it untouched
                     try:
                         return sub(*args, **kwargs)
                     except TypeError as e:
-                        if "required positional argument" in str(e) or (
-                            "required keyword-only argument" in str(e)
+                        if (
+                            "required positional argument" in str(e)
+                            or "required keyword-only argument" in str(e)
+                            or "unexpected keyword argument" in str(e)
                         ):
                             return wrapper(*args, **kwargs)
                         raise
@@ -179,6 +203,25 @@ def _skv_maybe(fn):
         return dispatcher_shim
     if isinstance(fn, np.ufunc):
         def ufunc_shim(*args, **kwargs):
+            if any(_traced(a) and not isinstance(a, Pair) for a in args):
+                # an object array HOLDING Pairs: numpy's object loop
+                # cannot dispatch a mapped ufunc. Apply elementwise;
+                # each scalar call re-enters the traced path
+                target = kwargs.pop("out", None)
+                if isinstance(target, tuple):
+                    target = target[0]
+                bcast = np.broadcast_arrays(
+                    *[np.asarray(a, dtype=object) for a in args]
+                )
+                out = np.empty(bcast[0].shape, dtype=object)
+                for idx in np.ndindex(bcast[0].shape):
+                    out[idx] = fn(*[b[idx] for b in bcast], **kwargs)
+                if target is not None:
+                    # out= on an object array: element replacement is
+                    # the in-place semantics callers rely on
+                    target[...] = out
+                    return target
+                return out
             if any(
                 isinstance(a, np.ndarray)
                 and a.dtype == object

--- a/skverify/instrument/twins.py
+++ b/skverify/instrument/twins.py
@@ -21,6 +21,10 @@ from ..session import current as _session
 from .registries import OPAQUE_CALLABLES
 from .rewriter import _Rewriter
 from .runtime import (
+    _skv_dict,
+    _skv_cmp,
+    _skv_float,
+    _skv_getitem,
     _skv_set,
     _skv_at,
     _skv_concrete,
@@ -146,6 +150,10 @@ def _instrument(fn, depth, seen, extra=None):
     namespace["__skv_scalarize__"] = _skv_scalarize
     namespace["__skv_isinstance__"] = _skv_isinstance
     namespace["__skv_set__"] = _skv_set
+    namespace["__skv_dict__"] = _skv_dict
+    namespace["__skv_getitem__"] = _skv_getitem
+    namespace["__skv_cmp__"] = _skv_cmp
+    namespace["__skv_float__"] = _skv_float
     namespace["__skv_concrete_call__"] = _skv_concrete_call
     namespace["__skv_opaque_out__"] = _skv_opaque_out
     namespace["__skv_loop_iter__"] = _loop_iter

--- a/skverify/maps/numpy.py
+++ b/skverify/maps/numpy.py
@@ -28,6 +28,7 @@ UFUNC_TABLE.update({getattr(np, n): getattr(sympy, n) for n in _SAME})
 UFUNC_TABLE.update({getattr(np, k): getattr(sympy, v) for k, v in _RENAMED.items()})
 
 # Others
+UFUNC_TABLE[np.fabs] = sympy.Abs
 UFUNC_TABLE[np.maximum] = sympy.Max
 UFUNC_TABLE[np.minimum] = sympy.Min
 UFUNC_TABLE[np.arctan2] = sympy.atan2
@@ -178,7 +179,42 @@ def _fresh_dummy(formula, n_axes, base="j"):
     return sympy.Symbol(f"{base}{k}", integer=True)
 
 
+def _masked_fuse(a):
+    """(source, mask) provenance of a mask gather, popping its lazy
+    guards: the reduction that calls this absorbs the mask into the
+    formula, so the guards are not needed."""
+    prov = getattr(a, "_mask_prov", None)
+    if prov is None:
+        return None
+    from ..session import current as _session
+
+    _session.pending_mask_guards.pop(id(a), None)
+    return prov
+
+
 def _sum(a, axis=None, **kwargs):
+    prov = _masked_fuse(a) if isinstance(a, Pair) else None
+    if prov is not None and axis is None:
+        src, mask = prov
+        bounds = src._axis_bounds
+        if bounds is not None and len(bounds) == 1:
+            lo, hi = bounds[0]
+            i0 = axis_idx(0)
+            j = _fresh_dummy(sympy.Tuple(src.formula, mask.formula), 1)
+            body = sympy.Piecewise(
+                (src.formula.xreplace({i0: j}), mask.formula.xreplace({i0: j})),
+                (0, True),
+            )
+            return Pair(
+                np.sum(np.asarray(Pair._value_of(a.value), dtype=float)),
+                sympy.Sum(body, (j, lo, hi - 1)),
+                None,
+                steps=(a,),
+            )
+    return _sum_plain(a, axis=axis, **kwargs)
+
+
+def _sum_plain(a, axis=None, **kwargs):
     if kwargs:
         raise NotImplementedError(f"np.sum kwargs {list(kwargs)} not supported")
     if isinstance(a, Pair) and a.domain is None:
@@ -236,6 +272,41 @@ def _sum(a, axis=None, **kwargs):
     return Pair(np.sum(a.value), formula, None, steps=(a,))
 
 
+def _is_bag(x):
+    return (
+        isinstance(x, np.ndarray)
+        and x.dtype == object
+        and any(isinstance(e, Pair) for e in x.ravel())
+    )
+
+
+def _bag_matmul(a, b):
+    """matmul on decompressed operands: explicit per-element sums.
+
+    A bag has no single indexed pattern (rows may mix unrelated
+    formulas), but the contraction is still exact arithmetic on the
+    element Pairs -- Pair dunders carry both lanes."""
+    A = np.atleast_2d(np.asarray(a, dtype=object))
+    B = np.asarray(b, dtype=object)
+    one_d_b = B.ndim == 1
+    if one_d_b:
+        B = B[:, None]
+    n, m = A.shape
+    m2, p = B.shape
+    out = np.empty((n, p), dtype=object)
+    for i in range(n):
+        for j in range(p):
+            acc = A[i, 0] * B[0, j]
+            for kk in range(1, m):
+                acc = acc + A[i, kk] * B[kk, j]
+            out[i, j] = acc
+    if np.ndim(a) == 1:
+        out = out[0]
+    if one_d_b:
+        out = out[..., 0] if out.ndim else out
+    return out
+
+
 def _matmul(a, b):
     """Contraction as a Sum, numpy matmul semantics for every rank.
 
@@ -243,6 +314,11 @@ def _matmul(a, b):
     1-D operands lose their would-be axis; leading axes are batch dims
     and broadcast (an extent-1 batch axis indexes at 0).
     """
+    if (_is_bag(a) or _is_bag(b)) and np.ndim(a) <= 2 and np.ndim(b) <= 2:
+        return _bag_matmul(
+            a if _is_bag(a) else np.asarray(a, dtype=object),
+            b if _is_bag(b) else np.asarray(b, dtype=object),
+        )
     bounds_a, bounds_b = Pair._domain_of(a), Pair._domain_of(b)
     if bounds_a is None or bounds_b is None:
         raise ValueError("matmul: both operands must be at least 1-D")
@@ -457,6 +533,8 @@ def _diag(v, k=0):
 def _mean(a, axis=None, **kwargs):
     if isinstance(a, Pair):
         return a.mean(axis=axis)
+    if isinstance(a, np.ndarray) and a.ndim == 1 and axis in (0, -1):
+        axis = None  # the only axis of a 1-D array IS the flatten axis
     if (
         isinstance(a, np.ndarray)
         and a.dtype == object
@@ -486,6 +564,32 @@ def _std(a, axis=None, ddof=0, correction=None, **kwargs):
 
 
 def _median(a, axis=None, **kwargs):
+    if np.ndim(Pair._value_of(a)) == 1 and axis in (0, -1):
+        # the only axis of a 1-D array IS the flatten axis
+        axis = None
+    bag = (
+        isinstance(a, np.ndarray)
+        and a.dtype == object
+        and a.ndim == 1
+        and any(isinstance(e, Pair) for e in a.ravel())
+    )
+    if bag and axis is None:
+        # decompressed operand: same selection, element formulas
+        from ..pair import _GUARDS
+
+        vals = np.asarray(Pair._value_of(a), dtype=float)
+        order = np.argsort(vals, kind="stable")
+        forms = [Pair._formula_of(e) for e in a]
+        for k in range(len(order) - 1):
+            _GUARDS.append(
+                sympy.Le(forms[order[k]], forms[order[k + 1]])
+            )
+        mid = len(order) // 2
+        if len(order) % 2:
+            f = forms[order[mid]]
+        else:
+            f = (forms[order[mid - 1]] + forms[order[mid]]) / 2
+        return Pair(np.median(vals), f, None, steps=Pair._steps_of(*a))
     if not isinstance(a, Pair) or axis is not None or len(a._axis_bounds or ()) != 1:
         return np.median(np.asarray(Pair._value_of(a), dtype=float), axis=axis)
     from ..pair import _GUARDS
@@ -561,7 +665,33 @@ def _round(a, decimals=0, **kwargs):
 
 
 FUNCTION_TABLE[np.round] = _round
-def _average(a, axis=None, weights=None, **kwargs):
+def _average(a, axis=None, weights=None, returned=False, **kwargs):
+    if returned:
+        # (average, sum_of_weights): cov-style callers unpack both
+        avg = _average(a, axis=axis, weights=weights)
+        if weights is None:
+            n = np.shape(Pair._value_of(a))[axis] if axis is not None else np.size(
+                Pair._value_of(a)
+            )
+            scl_val, scl_f = float(n), sympy.Integer(int(n))
+        else:
+            w_total = float(np.sum(Pair._value_of(weights)))
+            scl_val, scl_f = w_total, Pair._formula_of(weights) if isinstance(
+                weights, Pair
+            ) else sympy.sympify(w_total)
+        # numpy returns the weight sum BROADCAST to the average's shape
+        # (cov unpacks w_sum[0]); match it
+        avg_shape = np.shape(Pair._value_of(avg))
+        scl = Pair(
+            np.full(avg_shape, scl_val) if avg_shape else scl_val,
+            scl_f,
+            tuple((0, int(d)) for d in avg_shape) or None,
+        )
+        return avg, scl
+    return _average_impl(a, axis=axis, weights=weights, **kwargs)
+
+
+def _average_impl(a, axis=None, weights=None, **kwargs):
     if not isinstance(a, Pair):
         arr = np.asarray(a)
         if (
@@ -612,6 +742,389 @@ def _concrete_inventory(np_fn):
     return entry
 
 
+def _bincount(x, weights=None, minlength=0):
+    """bincount as counting mathematics.
+
+    result[k] = Sum(Piecewise((w_j, Eq(x[j], k)), (0, True)), j) --
+    occurrence counting (or weighted counting) as an explicit Sum for
+    each bin. The bins themselves come from the concrete values (how
+    many bins exist is a trace fact); the counts stay symbolic.
+    """
+    xv = np.asarray(Pair._value_of(x)).astype(int)
+    n = len(xv)
+    n_bins = max(int(xv.max()) + 1 if n else 0, int(minlength))
+    concrete = np.bincount(xv, weights=Pair._value_of(weights) if weights is not None else None, minlength=minlength)
+    if not (isinstance(x, Pair) or (
+        isinstance(x, np.ndarray) and x.dtype == object
+    ) or isinstance(weights, Pair)):
+        return concrete
+    def elem_formulas(arr, m):
+        if isinstance(arr, np.ndarray) and arr.dtype == object:
+            return [Pair._formula_of(e) for e in arr.ravel()]
+        f = Pair._formula_of(arr)
+        i0 = axis_idx(0)
+        return [f.xreplace({i0: sympy.Integer(jj)}) for jj in range(m)]
+
+    bag = getattr(x, "skv_pairs", None)
+    if bag is not None:
+        out = np.empty(n_bins, dtype=object)
+        for k in range(n_bins):
+            terms = []
+            for elem, cond in bag:
+                e_f = Pair._formula_of(elem)
+                c_f = Pair._formula_of(cond) if isinstance(cond, Pair) else sympy.sympify(bool(cond))
+                terms.append(
+                    sympy.Piecewise(
+                        (1, sympy.And(c_f, sympy.Eq(e_f, k))), (0, True)
+                    )
+                )
+            out[k] = Pair(float(concrete[k]), sympy.Add(*terms), None)
+        return out
+    prov = _masked_fuse(x) if isinstance(x, Pair) else None
+    if prov is not None:
+        src, mask = prov
+        bounds = src._axis_bounds
+        if bounds is not None and len(bounds) == 1:
+            lo, hi = bounds[0]
+            i0 = axis_idx(0)
+            out = np.empty(n_bins, dtype=object)
+            for k in range(n_bins):
+                j = sympy.Symbol("j", integer=True)
+                body = sympy.Piecewise(
+                    (
+                        1,
+                        sympy.And(
+                            mask.formula.xreplace({i0: j}),
+                            sympy.Eq(src.formula.xreplace({i0: j}), k),
+                        ),
+                    ),
+                    (0, True),
+                )
+                out[k] = Pair(
+                    float(concrete[k]),
+                    sympy.Sum(body, (j, lo, hi - 1)),
+                    None,
+                )
+            return out
+    x_fs = elem_formulas(x, n)
+    if weights is None:
+        w_fs = [sympy.Integer(1)] * n
+    else:
+        w_fs = elem_formulas(weights, n)
+    out = np.empty(n_bins, dtype=object)
+    for k in range(n_bins):
+        count = sympy.Add(
+            *[
+                sympy.Piecewise((w_fs[jj], sympy.Eq(x_fs[jj], k)), (0, True))
+                for jj in range(n)
+            ]
+        )
+        out[k] = Pair(float(concrete[k]), count, None)
+    return out
+
+
+def _searchsorted(a, v, side="left", sorter=None):
+    """searchsorted as counting mathematics.
+
+    For ascending bins, the insertion index IS a count:
+    side='left'  -> index = Sum_k [bins[k] < v]
+    side='right' -> index = Sum_k [bins[k] <= v]
+    Bins concrete (an inventory), the searched values symbolic: each
+    result element carries its counting formula.
+    """
+    bins = np.asarray(Pair._value_of(a), dtype=float)
+    concrete = np.searchsorted(
+        bins, np.asarray(Pair._value_of(v), dtype=float), side=side, sorter=sorter
+    )
+    bins_traced = isinstance(a, Pair) or (
+        isinstance(a, np.ndarray) and a.dtype == object
+    )
+    v_traced = isinstance(v, Pair) or (
+        isinstance(v, np.ndarray) and v.dtype == object
+    )
+    if sorter is not None or not (bins_traced or v_traced):
+        return concrete
+    if bins_traced:
+        # symbolic bins: index = Sum_k [bins[k] rel v], valid only for
+        # sorted bins -- the ordering is recorded as preconditions
+        from ..session import current as _session
+
+        i0 = axis_idx(0)
+        n = bins.size
+        b_f = [Pair._formula_of(a).subs(i0, k) if isinstance(a, Pair)
+               else Pair._formula_of(a.ravel()[k]) for k in range(n)]
+        for k in range(n - 1):
+            _session.guards.append(sympy.Le(b_f[k], b_f[k + 1]))
+        rel = sympy.Lt if side == "left" else sympy.Le
+
+        def count_for(target_f):
+            return sympy.Add(
+                *[sympy.Piecewise((1, rel(bf, target_f)), (0, True))
+                  for bf in b_f]
+            )
+
+        if np.ndim(concrete) == 0:
+            return Pair(
+                concrete, count_for(Pair._formula_of(v)), None,
+                steps=Pair._steps_of(a, v),
+            )
+        v_f = Pair._formula_of(v)
+        out = np.empty(np.shape(concrete), dtype=object)
+        for j in range(out.size):
+            out.ravel()[j] = Pair(
+                concrete.ravel()[j], count_for(v_f.subs(i0, j)), None,
+                steps=Pair._steps_of(a, v),
+            )
+        return out
+    v_f = Pair._formula_of(v)
+    i0 = axis_idx(0)
+    rel = sympy.Lt if side == "left" else sympy.Le
+
+    def index_formula(elem_formula):
+        return sympy.Add(
+            *[
+                sympy.Piecewise(
+                    (1, rel(sympy.Float(b), elem_formula)), (0, True)
+                )
+                for b in bins
+            ]
+        )
+
+    if np.ndim(concrete) == 0:
+        return Pair(int(concrete), index_formula(v_f), None)
+    out = np.empty(len(concrete), dtype=object)
+    for jj in range(len(concrete)):
+        out[jj] = Pair(
+            int(concrete[jj]), index_formula(v_f.xreplace({i0: jj})), None
+        )
+    return out
+
+
+def _nan_reduce(np_fn, kind):
+    """nan-aware reductions: WHICH entries are nan is a trace fact;
+    the surviving elements reduce symbolically."""
+
+    def entry(a, axis=None, **kwargs):
+        vals = np.asarray(Pair._value_of(a), dtype=float)
+        if axis is not None or not (
+            isinstance(a, Pair)
+            or (isinstance(a, np.ndarray) and a.dtype == object)
+        ):
+            return np_fn(vals, axis=axis, **kwargs)
+        if isinstance(a, np.ndarray):
+            elems = list(a.ravel())
+        else:
+            elems = [a[k] for k in range(len(vals.ravel()))]
+        keep = [e for e, v in zip(elems, vals.ravel()) if not np.isnan(v)]
+        if not keep:
+            return np_fn(vals, **kwargs)
+        total = keep[0]
+        for e in keep[1:]:
+            total = total + e
+        return total / len(keep) if kind == "mean" else total
+
+    return entry
+
+
+def _nanmedian(a, axis=None, **kwargs):
+    """nan-aware median: WHICH entries are nan is a trace fact; the
+    survivors' median is a path-scoped selection under explicit
+    ordering preconditions (same contract as np.median)."""
+    vals = np.asarray(Pair._value_of(a), dtype=float)
+    traced = isinstance(a, Pair) or (
+        isinstance(a, np.ndarray) and a.dtype == object
+    )
+    if not traced or kwargs:
+        return np.nanmedian(vals, axis=axis, **kwargs)
+    from ..pair import _GUARDS
+
+    def elem_formula(idx):
+        if isinstance(a, Pair):
+            f = a.formula
+            for ax, k in enumerate(idx):
+                f = f.subs(axis_idx(ax), int(k))
+            return f
+        return Pair._formula_of(a[idx])
+
+    def median_of(cells):
+        # cells: list of index tuples into vals, nans already dropped
+        cells = sorted(cells, key=lambda idx: vals[idx])
+        for k in range(len(cells) - 1):
+            _GUARDS.append(
+                sympy.Le(elem_formula(cells[k]), elem_formula(cells[k + 1]))
+            )
+        mid = len(cells) // 2
+        if len(cells) % 2:
+            f = elem_formula(cells[mid])
+        else:
+            f = (elem_formula(cells[mid - 1]) + elem_formula(cells[mid])) / 2
+        v = np.nanmedian([vals[c] for c in cells])
+        return Pair(v, f, None, steps=Pair._steps_of(a))
+
+    live = [idx for idx in np.ndindex(vals.shape) if not np.isnan(vals[idx])]
+    if not live:
+        return np.nanmedian(vals, axis=axis)
+    if axis is None:
+        return median_of(live)
+    axis = axis % vals.ndim
+    out_shape = vals.shape[:axis] + vals.shape[axis + 1 :]
+    out = np.empty(out_shape, dtype=object)
+    for oidx in np.ndindex(out_shape):
+        cells = [
+            idx for idx in live
+            if idx[:axis] + idx[axis + 1 :] == oidx
+        ]
+        out[oidx] = (
+            median_of(cells) if cells else np.nan
+        )
+    return out
+
+
+def _mutating_write(np_fn):
+    """copyto/place/putmask as the assignments they secretly are.
+
+    Their whole output is a side effect on the destination; treating
+    them as calls loses the write. Route both lanes through Pair's
+    setitem machinery instead, or refuse when the write cannot be
+    represented -- never pass through silently."""
+
+    def entry(dst, *args, **kwargs):
+        if not isinstance(dst, Pair):
+            raise NotImplementedError(
+                f"{np_fn.__name__} into a non-traced destination holding "
+                "traced values; assign with dst[...] = src instead"
+            )
+        if kwargs:
+            raise NotImplementedError(
+                f"{np_fn.__name__} with options is not supported"
+            )
+        if np_fn is np.copyto:
+            (src,) = args
+            dst[...] = src
+            return None
+        mask, vals = args
+        v = np.asarray(Pair._value_of(vals))
+        if np_fn is np.place and v.size != 1 and v.size != int(
+            np.count_nonzero(np.asarray(Pair._value_of(mask), dtype=bool))
+        ):
+            # np.place CYCLES a short vals list through the mask; a
+            # cycled write has no honest single formula
+            raise NotImplementedError(
+                "np.place with a cycled values list is not supported"
+            )
+        dst[mask] = vals if np.ndim(vals) == 0 or v.size != 1 else (
+            vals[0] if not isinstance(vals, Pair) else vals
+        )
+        return None
+
+    return entry
+
+
+def _nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
+    """nan_to_num exactly: WHICH entries are nan/inf is a trace fact.
+
+    Finite positions keep their formulas; non-finite positions become
+    the replacement constants numpy would write (the huge finfo bounds
+    for inf unless overridden)."""
+    vals = np.asarray(Pair._value_of(x), dtype=float)
+    fixed = np.nan_to_num(vals, copy=copy, nan=nan, posinf=posinf, neginf=neginf)
+    if not isinstance(x, Pair):
+        return fixed
+    if np.all(np.isfinite(vals)):
+        return Pair(fixed, x.formula, x._axis_bounds, steps=(x,))
+    if vals.ndim == 0:
+        return Pair(fixed, sympy.Float(float(fixed)), None, steps=(x,))
+    sym = axis_idx(0)
+    out = np.empty(vals.shape, dtype=object)
+    for idx in np.ndindex(vals.shape):
+        if np.isfinite(vals[idx]):
+            f = x.formula
+            for ax, k in enumerate(idx):
+                f = f.subs(axis_idx(ax), int(k))
+        else:
+            f = sympy.Float(float(fixed[idx]))
+        out[idx] = Pair(fixed[idx], f, None, steps=(x,))
+    return out
+
+
+def _select(condlist, choicelist, default=0):
+    """np.select is chained np.where; its body only adds a dtype gate
+    that rejects traced masks. Same Piecewise, built directly."""
+    out = _where(condlist[-1], choicelist[-1], default)
+    for cond, choice in zip(condlist[-2::-1], choicelist[-2::-1]):
+        out = _where(cond, choice, out)
+    return out
+
+
+def _interp(x, xp, fp, left=None, right=None, period=None):
+    """Piecewise-linear interpolation, exactly.
+
+    The table (xp, fp) concrete and the query traced: the exact
+    Piecewise over the table's intervals. Compiled internals make a
+    table entry the honest route; a traced TABLE has no closed
+    branch-free form and refuses."""
+    if period is not None:
+        raise NotImplementedError("np.interp with period is not supported")
+    concrete = np.interp(
+        np.asarray(Pair._value_of(x), dtype=float),
+        np.asarray(Pair._value_of(xp), dtype=float),
+        np.asarray(Pair._value_of(fp), dtype=float),
+        left=left,
+        right=right,
+    )
+    if isinstance(xp, Pair) or isinstance(fp, Pair) or _is_bag(xp) or _is_bag(fp):
+        raise NotImplementedError(
+            "np.interp with a traced table: the interval selection has "
+            "no single exact formula; interpolate explicitly instead"
+        )
+    if not (isinstance(x, Pair) or _is_bag(x)):
+        return concrete
+    xs = np.asarray(xp, dtype=float)
+    fs = np.asarray(fp, dtype=float)
+    lo = float(fs[0]) if left is None else float(left)
+    hi = float(fs[-1]) if right is None else float(right)
+
+    def branchwise(q):
+        pieces = [(sympy.Float(lo), q < float(xs[0]))]
+        for k in range(len(xs) - 1):
+            x0, x1 = float(xs[k]), float(xs[k + 1])
+            f0, f1 = float(fs[k]), float(fs[k + 1])
+            slope = (f1 - f0) / (x1 - x0) if x1 != x0 else 0.0
+            pieces.append((f0 + slope * (q - x0), q <= x1))
+        pieces.append((sympy.Float(hi), True))
+        return sympy.Piecewise(*pieces)
+
+    if np.ndim(Pair._value_of(x)) == 0:
+        return Pair(
+            float(concrete), branchwise(Pair._formula_of(x)), None,
+            steps=Pair._steps_of(x),
+        )
+    sym = axis_idx(0)
+    out = np.empty(np.shape(concrete), dtype=object)
+    for k in range(out.size):
+        qf = (
+            Pair._formula_of(x).subs(sym, k)
+            if isinstance(x, Pair)
+            else Pair._formula_of(x.ravel()[k])
+        )
+        out.ravel()[k] = Pair(
+            float(np.ravel(concrete)[k]), branchwise(qf), None,
+            steps=Pair._steps_of(x),
+        )
+    return out
+
+
+FUNCTION_TABLE[np.select] = _select
+FUNCTION_TABLE[np.interp] = _interp
+FUNCTION_TABLE[np.nan_to_num] = _nan_to_num
+FUNCTION_TABLE[np.copyto] = _mutating_write(np.copyto)
+FUNCTION_TABLE[np.place] = _mutating_write(np.place)
+FUNCTION_TABLE[np.putmask] = _mutating_write(np.putmask)
+FUNCTION_TABLE[np.nanmedian] = _nanmedian
+FUNCTION_TABLE[np.nanmean] = _nan_reduce(np.nanmean, "mean")
+FUNCTION_TABLE[np.nansum] = _nan_reduce(np.nansum, "sum")
+FUNCTION_TABLE[np.searchsorted] = _searchsorted
+FUNCTION_TABLE[np.bincount] = _bincount
 FUNCTION_TABLE[np.isin] = _concrete_inventory(np.isin)
 FUNCTION_TABLE[np.setdiff1d] = _concrete_inventory(np.setdiff1d)
 FUNCTION_TABLE[np.union1d] = _concrete_inventory(np.union1d)

--- a/skverify/maps/special.py
+++ b/skverify/maps/special.py
@@ -33,6 +33,10 @@ def _register():
         "kv": sympy.besselk,
     }
     composed = {
+        # chi2 survival function: Q(v/2, x/2), the regularized upper
+        # incomplete gamma -- exact, differentially tested
+        "chdtrc": lambda v, x: sympy.uppergamma(v / 2, x / 2) / sympy.gamma(v / 2),
+        "chdtr": lambda v, x: sympy.lowergamma(v / 2, x / 2) / sympy.gamma(v / 2),
         "ndtr": lambda z: (1 + sympy.erf(z / sympy.sqrt(2))) / 2,
         "log_ndtr": lambda z: sympy.log((1 + sympy.erf(z / sympy.sqrt(2))) / 2),
         "expit": lambda z: 1 / (1 + sympy.exp(-z)),

--- a/skverify/pair.py
+++ b/skverify/pair.py
@@ -77,6 +77,14 @@ class Pair:
         text = sympy.latex(self.formula)
         return f"$\\displaystyle {text}$"
 
+    def __format__(self, spec):
+        if not spec:
+            return str(self)
+        raise NotImplementedError(
+            "formatting a traced value into a string discards the "
+            "formula; format .value for display"
+        )
+
     def __repr__(self):
         text = str(self.formula)
         if len(text) > 60:
@@ -793,6 +801,51 @@ class Pair:
 
     __rmul__ = __mul__
 
+    def __floordiv__(self, other):
+        if Pair._defers(other):
+            return NotImplemented
+        mine, theirs, merged = Pair._broadcast(self, other)
+        return Pair(
+            value=self.value // Pair._value_of(other),
+            formula=sympy.floor(mine / theirs),
+            domain=merged,
+            steps=Pair._steps_of(self, other),
+        )
+
+    def __rfloordiv__(self, other):
+        if Pair._defers(other):
+            return NotImplemented
+        mine, theirs, merged = Pair._broadcast(self, other)
+        return Pair(
+            value=Pair._value_of(other) // self.value,
+            formula=sympy.floor(theirs / mine),
+            domain=merged,
+            steps=Pair._steps_of(self, other),
+        )
+
+    def __divmod__(self, other):
+        return (self // other, self % other)
+
+    def __rdivmod__(self, other):
+        return (other // self, other % self)
+
+    def __round__(self, ndigits=None):
+        # exact except at half-way ties, where Python rounds to even
+        # and floor(x + 1/2) rounds up: the tie-free condition is
+        # recorded as a path guard, same contract as median's ordering
+        n = 0 if ndigits is None else int(ndigits)
+        scale = sympy.Integer(10) ** n
+        _GUARDS.append(
+            sympy.Ne(sympy.Mod(self.formula * scale + sympy.Rational(1, 2), 1), 0)
+        )
+        formula = sympy.floor(self.formula * scale + sympy.Rational(1, 2)) / scale
+        value = round(
+            float(np.asarray(self.value).item()), ndigits if ndigits is not None else 0
+        )
+        if ndigits is None:
+            value = int(value)
+        return Pair(value, formula, None, steps=(self,))
+
     def __mod__(self, other):
         if Pair._defers(other):
             return NotImplemented
@@ -890,6 +943,20 @@ class Pair:
 
     # facts about the concrete lane; some library bodies read these
     # before doing any math
+    def fill(self, value):
+        # ndarray.fill is a whole-array overwrite: both lanes at once
+        self[...] = value
+
+    def tolist(self):
+        # decompression to scalar Pairs: each element keeps its formula
+        out = self[...] if np.ndim(self.value) else self
+        return [out[k] for k in range(len(np.asarray(self.value)))]
+
+    @property
+    def base(self):
+        # memory-ownership bookkeeping, not math: view checks read it
+        return np.asarray(self.value).base
+
     @property
     def ndim(self):
         return np.ndim(self.value)
@@ -1037,9 +1104,8 @@ class Pair:
 
     def astype(self, dtype=None, copy=True, **kwargs):
         # float casts are math-neutral. Integer casts are LABEL
-        # bookkeeping when the values are already integral (0/1 class
-        # arrays through classification metrics); truncation of
-        # non-integral values would change the math and refuses.
+        # bookkeeping when the values are already integral; truncation
+        # of non-integral values would change the math and refuses.
         vals = np.asarray(Pair._value_of(self.value))
         if dtype is not None and np.dtype(dtype).kind not in "fc":
             if np.dtype(dtype).kind in "iub" and np.all(vals == np.floor(vals)):
@@ -1136,6 +1202,14 @@ class Pair:
         assert n == hi - lo, "domain drifted from value"
         return n
 
+    def __iter__(self):
+        # explicit protocol: pandas' is_list_like (and any hasattr
+        # check) must see an array, not a scalar. Elements keep their
+        # formulas via the same indexing path as unpacking
+        if self._axis_bounds is None:
+            raise TypeError("scalar Pair is not iterable")
+        return (self[k] for k in range(len(self)))
+
     def __getitem__(self, key):
         """Slicing and integer indexing; 1-D is just the N=1 case."""
         if isinstance(key, tuple) and key == ():
@@ -1143,25 +1217,33 @@ class Pair:
         if self._axis_bounds is None:
             raise TypeError("scalar Pair is not subscriptable")
         if isinstance(key, Pair) and Pair._is_condition(key.formula):
-            # mask gather u[u > 0]: the mask's VALUE fixes the selected
-            # positions (trace facts); the mask's CONDITIONS become
-            # per-position preconditions, so the certificate is honest
-            # about the path
+            # mask gather u[u > 0]: the selection is data-dependent, but
+            # its GUARDS are recorded lazily. If a reduction consumes
+            # the gather (sum, bincount, mean -- the overwhelmingly
+            # common case), it fuses the mask INTO the formula as a
+            # Piecewise over the full range and no guards are needed;
+            # any other use flushes the per-position guards at harvest,
+            # keeping the certificate honest either way.
             mask = np.asarray(key.value, dtype=bool)
             sym = axis_idx(0)
+            pending = []
             for pos in range(mask.size):
                 cond = key.formula.subs(sym, pos)
-                _GUARDS.append(cond if mask[pos] else sympy.Not(cond))
+                pending.append(cond if mask[pos] else sympy.Not(cond))
             idx = np.nonzero(mask)[0]
             if idx.size == 0:
                 value = np.asarray(self.value)[mask]
-                return Pair(
+                out = Pair(
                     value,
                     self.formula,
                     ((0, 0),) + tuple(self._axis_bounds[1:]),
                     steps=(self,),
                 )
-            return self._axis_gather(0, idx, mask)
+            else:
+                out = self._axis_gather(0, idx, mask)
+            out._mask_prov = (self, key)
+            _session.pending_mask_guards[id(out)] = pending
+            return out
         parts = key if isinstance(key, tuple) else (key,)
         if any(k is None for k in parts):
             # w[:, None]: newaxis only inserts extent-1 axes -- apply the

--- a/skverify/session.py
+++ b/skverify/session.py
@@ -50,6 +50,7 @@ class TraceSession:
         self.fn_twins = {}
         self.class_twins = {}
         self.hashed = set()
+        self.pending_mask_guards = {}
         self.seq = 0
 
     def reset(self):
@@ -66,6 +67,7 @@ class TraceSession:
         self.fn_twins.clear()
         self.class_twins.clear()
         self.hashed.clear()
+        self.pending_mask_guards.clear()
         self.seq = 0
 
     def next_seq(self):

--- a/skverify/sets.py
+++ b/skverify/sets.py
@@ -13,7 +13,6 @@ membership answers with the concrete truth. The formula stays exact
 under the traced input, which is the library-wide contract.
 """
 
-import numpy as np
 import sympy
 
 from .coercion import formula_of, value_of
@@ -91,4 +90,62 @@ class TracedSet:
             other,
             set.symmetric_difference,
             lambda a, b: sympy.SymmetricDifference(a, b),
+        )
+
+
+class TracedDict:
+    """A dict whose lookups by traced keys are SELECTIONS.
+
+    The value lane behaves exactly like the dict it wraps. A lookup
+    with a traced key returns a Pair whose formula is the Piecewise
+    selection over the table: ``d[y]`` where ``d = {0.0: 0, 1.0: 1}``
+    yields ``Piecewise((0, Eq(y, 0.0)), (1, Eq(y, 1.0)))``. Encoding
+    steps (label -> index maps) thereby keep their mathematics.
+    """
+
+    def __init__(self, mapping):
+        self._data = dict(mapping)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def keys(self):
+        return self._data.keys()
+
+    def values(self):
+        return self._data.values()
+
+    def items(self):
+        return self._data.items()
+
+    def __contains__(self, key):
+        return _scalar(value_of(key)) in self._data
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __getitem__(self, key):
+        from .pair import Pair
+
+        concrete_key = _scalar(value_of(key))
+        stored = self._data[concrete_key]
+        if not isinstance(key, Pair):
+            return stored
+        pieces = []
+        for k, v in self._data.items():
+            k_f = formula_of(_scalar(value_of(k)))
+            v_f = formula_of(_scalar(value_of(v)))
+            pieces.append((v_f, sympy.Eq(key.formula, k_f)))
+        formula = sympy.Piecewise(*pieces, (sympy.nan, True))
+        return Pair(
+            value_of(stored) if isinstance(stored, Pair) else stored,
+            formula,
+            None,
+            steps=(key,),
         )

--- a/tests/coercion/test_no_silent_constants.py
+++ b/tests/coercion/test_no_silent_constants.py
@@ -12,7 +12,7 @@ scipy_stats = pytest.importorskip("scipy.stats")
 
 # open silent-loss bugs, tracked by name; fixing one means removing
 # it here. ADDING a name requires a documented diagnosis, not a wave.
-KNOWN_SILENT = {"sem", "trim_mean"}
+KNOWN_SILENT = {"sem"}
 # context-dependent (flag 27): symbolic standalone, constant/crash under
 # other import orders -- the twin caches are order-dependent. These are
 # NOT stable results; the flag-27 unification is the fix.

--- a/tests/instrument/test_guards.py
+++ b/tests/instrument/test_guards.py
@@ -87,15 +87,16 @@ class TestGuardedLibraryCode:
         P = sympy.IndexedBase("p")
         assert out.formula.has(P[0]) and out.formula.has(P[2])
 
-    def test_searchsorted_constant_under_path(self):
-        # a guarded C bisection returns a plain int: wrapped as a CONSTANT
-        # whose preconditions are the search's recorded bracketing
+    def test_searchsorted_counting_form(self):
+        # the insertion index IS a count: Sum_k [a[k] < v], exact for
+        # sorted bins -- the ordering rides in the preconditions
         x = np.array([10.0, 20.0, 30.0, 40.0])
         s = to_sympy(lambda a: np.searchsorted(a, 25), x)
-        assert s.formula == sympy.Integer(2)
         assert int(s.value) == 2
         A = sympy.IndexedBase("a")
-        assert s.preconditions.has(sympy.Lt(A[1], 25))
+        subs = {A[k]: x[k] for k in range(4)}
+        assert s.formula.doit().subs(subs) == 2
+        assert s.preconditions.has(sympy.Le(A[1], A[2]))
 
     def test_median_lifts_path_scoped(self):
         out = to_sympy(np.median, np.array([3.0, 1.0, 2.0]))

--- a/tests/instrument/test_mask_fusion.py
+++ b/tests/instrument/test_mask_fusion.py
@@ -1,0 +1,145 @@
+"""The mask-gather -> reduction fusion, end to end.
+
+A bool mask born from comparing traced arrays keeps its per-position
+conditions; gathering by it carries (element, condition) provenance;
+a reduction fuses the conditions INTO its formula instead of dumping
+one guard per position. The payoff: counting metrics like precision
+emerge as ratios of counting sums from generic tracing alone.
+"""
+
+import numpy as np
+import pytest
+import sympy
+
+from skverify import to_sympy
+
+
+def masked_total(x, t):
+    m = x > t
+    kept = x[m]
+    return np.sum(kept)
+
+
+class TestFusion:
+    def test_reduction_fuses_mask_into_formula(self):
+        x = np.array([1.0, -2.0, 3.0, -4.0])
+        out = to_sympy(masked_total, x, 0.0)
+        assert float(out.value) == 4.0
+        X = sympy.IndexedBase("x")
+        # the mask lives inside the formula, not in the preconditions
+        assert out.formula.has(sympy.Piecewise) or out.formula.has(sympy.Sum)
+        assert out.preconditions is sympy.true
+        subs = {X[k]: v for k, v in enumerate(x)}
+        subs[sympy.Symbol("t", real=True)] = 0.0
+        assert float(out.formula.doit().subs(subs)) == 4.0
+        # and the formula is a real function of the input: flip a sign
+        flipped = dict(subs)
+        flipped[X[2]] = -3.0
+        assert float(out.formula.doit().subs(flipped)) == 1.0
+
+    def test_precision_emerges_as_counting_ratio(self):
+        sklearn = pytest.importorskip("sklearn")
+        from sklearn.metrics import precision_score
+
+        y_t = np.array([0, 1, 1, 0, 1, 0, 1, 1], dtype=float)
+        y_p = np.array([0, 1, 0, 0, 1, 1, 1, 1], dtype=float)
+        out = to_sympy(precision_score, y_t, y_p)
+        assert float(out.value) == precision_score(y_t, y_p)
+        # not a constant: a ratio over per-sample conditions
+        T = sympy.IndexedBase("y_true")
+        P = sympy.IndexedBase("y_pred")
+        assert out.formula.has(T) and out.formula.has(P)
+        subs = {T[k]: v for k, v in enumerate(y_t)}
+        subs.update({P[k]: v for k, v in enumerate(y_p)})
+        got = out.formula.doit().subs(subs)
+        assert float(got) == precision_score(y_t, y_p)
+
+
+class TestNanMedian:
+    def test_axis_median_with_ordering_preconditions(self):
+        x = np.array([[3.0, 1.0], [1.0, 5.0], [2.0, 4.0]])
+        out = to_sympy(lambda a: np.nanmedian(a, axis=0), x)
+        assert np.allclose(
+            np.asarray(out.value, dtype=float), np.nanmedian(x, axis=0)
+        )
+        X = sympy.IndexedBase("a")
+        col0 = np.ravel(out.formula)[0]
+        # odd count: the median IS one symbolic element, chosen
+        # path-scoped under the recorded ordering (here both columns'
+        # medians sit in row 2, so harvest recompresses to a[2, i])
+        assert col0.subs(sympy.Symbol("i", integer=True), 0) == X[2, 0]
+        assert out.preconditions.has(sympy.Le(X[1, 0], X[2, 0]))
+
+
+class TestMutators:
+    """In-place numpy mutators are assignments in disguise: both lanes
+    must observe the write, or the call must refuse -- never no-op."""
+
+    def test_add_at_accumulates_on_both_lanes(self):
+        def f(x):
+            y = x * 1.0
+            np.add.at(y, [0, 0], 1.0)
+            return y[0]
+
+        out = to_sympy(f, np.array([1.5, -2.0, 3.25, 0.5]))
+        assert float(out.value) == 3.5
+        X = sympy.IndexedBase("x")
+        assert out.formula.subs(X[0], 1.5) == 3.5
+
+    def test_place_and_putmask_write_through(self):
+        def g(x):
+            y = x * 1.0
+            np.place(y, y < 0, [0.0])
+            return np.sum(y)
+
+        x = np.array([1.5, -2.0, 3.25, 0.5])
+        out = to_sympy(g, x)
+        assert float(out.value) == 5.25
+
+    def test_copyto_writes_both_lanes(self):
+        def h(x):
+            y = np.zeros(4)
+            np.copyto(y, x * 2)
+            return y[1]
+
+        out = to_sympy(h, np.array([1.5, -2.0, 3.25, 0.5]))
+        assert float(out.value) == -4.0
+        X = sympy.IndexedBase("x")
+        assert out.formula.subs(X[1], -2.0) == -4.0
+
+    def test_fill_and_tolist(self):
+        def k(x):
+            y = x * 1.0
+            y.fill(2.0)
+            return y[0] + x.tolist()[1]
+
+        out = to_sympy(k, np.array([1.5, -2.0, 3.25, 0.5]))
+        assert float(out.value) == 0.0
+
+
+class TestCoercionHonesty:
+    def test_nan_to_num_clamps_like_numpy(self):
+        def f(x):
+            with np.errstate(divide="ignore"):
+                return np.nan_to_num(x / 0.0)[1]
+
+        x = np.array([1.5, -2.0, 3.25, 0.5])
+        out = to_sympy(f, x)
+        with np.errstate(divide="ignore"):
+            assert float(out.value) == np.nan_to_num(x / 0.0)[1]
+
+    def test_int_argument_assumption_is_disclosed(self):
+        out = to_sympy(lambda a: a + 1, 3)
+        assert int(out.value) == 4
+        assert any("integer argument" in str(r) for r in out.unchecked)
+
+    def test_pandas_series_decompresses(self):
+        pd = pytest.importorskip("pandas")
+
+        def f(x):
+            return pd.Series(x).sum()
+
+        x = np.array([1.5, -2.0, 3.25, 0.5])
+        out = to_sympy(f, x)
+        assert float(out.value) == pd.Series(x).sum()
+        assert out.formula.has(sympy.Sum)

--- a/tests/pair/test_relational.py
+++ b/tests/pair/test_relational.py
@@ -209,14 +209,17 @@ class TestEdges:
         m = u == 0.5
         assert m.formula == sympy.Eq(U[I], 0.5)
 
-    def test_bool_indexing_gathers_with_guards(self):
-        from skverify.pair import _GUARDS
+    def test_bool_indexing_gathers_with_lazy_guards(self):
+        from skverify.session import current as _session
 
         u = make()
-        _GUARDS.clear()
+        _session.pending_mask_guards.clear()
         r = u[u > 0]
         assert np.allclose(np.asarray(r.value, dtype=float), u.value[u.value > 0])
-        assert len(_GUARDS) == len(u.value)  # every position's condition recorded
+        # every position's condition is recorded LAZILY: a fusing
+        # reduction pops them; an unfused gather flushes them at harvest
+        (pending,) = _session.pending_mask_guards.values()
+        assert len(pending) == len(u.value)
 
     def test_isnan_goes_opaque(self):
         u = make()


### PR DESCRIPTION
Precision emerges as TP/(TP+FP) from generic tracing: comparisons on object arrays keep their conditions (concrete bool lane + provenance), gathers carry (element, condition) pairs, and reductions fuse the mask INTO the formula instead of flooding guards. float() in twins keeps the pair. searchsorted with traced bins emits its counting Sum under sortedness preconditions instead of an unguarded constant.

The adversarial break pass (~200 cases, FAILURES.md) found five silent wrongs, all fixed: ufunc.at no longer collides with array_api_extra's at(); place/putmask/copyto route through setitem as the assignments they are; nan_to_num clamps like numpy; integer arguments disclose the traced-as-config assumption; Pair.__iter__ lets pandas see an array.

Class B coverage: round/divmod/floordiv/format dunders; cov and corrcoef trace numpy's own bodies (average honors returned=True, bag matmul builds per-element sums when no single pattern exists); select and interp entries where internals are hostile or compiled; inv and eigvals become contracted atoms; *args signatures wrap per-argument.

LOOP_DOMAINS.md: execution-verified design note for folding loops into sympy-native recurrence domains (RecursiveSeq / MatPow / Iterate).