### PR TITLE
repack accepts constants riding in a bag

### DIFF
--- a/skverify/api.py
+++ b/skverify/api.py
@@ -228,10 +228,22 @@ def _repack(out):
     if not (isinstance(out, np.ndarray) and out.dtype == object):
         return out
     elements = out.ravel()
-    if not all(isinstance(p, Pair) for p in elements):
+    if not all(
+        isinstance(p, Pair) or isinstance(p, (int, float, np.number))
+        for p in elements
+    ):
         return out  # not ours: leave untouched
-    values = np.array([p.value for p in elements]).reshape(out.shape)
-    formulas = [p.formula for p in elements]
+    if not any(isinstance(p, Pair) for p in elements):
+        return out
+    # plain numbers riding along (a column of ones from add_constant)
+    # are constants of the formula, not foreign objects
+    values = np.array(
+        [p.value if isinstance(p, Pair) else p for p in elements]
+    ).reshape(out.shape)
+    formulas = [
+        p.formula if isinstance(p, Pair) else sympy.sympify(p)
+        for p in elements
+    ]
     if out.ndim == 1:
         general = _recompress(formulas)
         if general is not None:


### PR DESCRIPTION
add_constant returns a column of plain ones next to traced values; the all-Pairs gate left the whole result unwrapped. Plain numbers in an object array are constants of the formula: add_constant certifies as [[1, data[0]], [1, data[1]], ...], and OLS.predict passes free (bag matmul already covered it). statsmodels battery: 9 -> 10.