### PR TITLE
[DOC] Add Sphinx documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -1,0 +1,12 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2870
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 # Overview\
+\
+```\{include\} ../../README.md\
+```\
+}

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -1,12 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2870
-\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
-\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+# Overview
 
-\f0\fs24 \cf0 # Overview\
-\
-```\{include\} ../../README.md\
-```\
-}
+```{include} ../../README.md
+```

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,4 @@
+API Reference
+=============
+
+.. autofunction:: skverify.to_sympy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,24 +4,27 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Project information -----------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'scikit-verify'
-copyright = '2026, aadya940'
-author = 'aadya940'
+copyright = '2026, Aadya Chinubhai'
+author = 'Aadya Chinubhai'
 
 # -- General configuration ---------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'myst_parser',
+]
 
 templates_path = ['_templates']
 exclude_patterns = []
 
-language = 'It should be a clean documentation that renders:'
+language = 'en'
+
+# the included repo README links to repo files that are not docs pages
+suppress_warnings = ['myst.xref_missing']
 
 # -- Options for HTML output -------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,27 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'scikit-verify'
+copyright = '2026, aadya940'
+author = 'aadya940'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+language = 'It should be a clean documentation that renders:'
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/source/design_philosophy.md
+++ b/docs/source/design_philosophy.md
@@ -1,0 +1,12 @@
+# Design Philosophy
+
+`scikit-verify` bridges the gap between concrete Python execution and symbolic verification. 
+
+## The Exact-or-Refuse Contract
+If an operation has no faithful symbolic form, `scikit-verify` raises an error instead of guessing. The goal is to avoid silent mistranslations and maintain strict mathematical correctness.
+
+## Lineage and Foundations
+Our stance relies heavily on classic computer science foundations:
+* **Concolic Style Execution**: Pairing concrete execution with symbolic pathways (King, 1976; Cadar & Sen).
+* **Result Checking**: Verifying a routine's outcome against its core defining equations (Blum & Kannan, 1989).
+* **Verified Lifting**: Translating operations upwards for correctness assurances.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Welcome to scikit-verify's documentation!
    :maxdepth: 2
    :caption: Documentation Navigation:
 
-   readme
+   README
    api
    design_philosophy
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,17 @@
+Welcome to scikit-verify's documentation!
+=========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Documentation Navigation:
+
+   readme
+   api
+   design_philosophy
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dynamic = ["version"]
 [project.optional-dependencies]
 mcp = ["mcp>=1.2,<2"]
 hypothesis = ["hypothesis>=6"]
+docs = [
+    "sphinx>=7",
+    "sphinx-rtd-theme>=2",
+    "myst-parser>=3",
+]
 dev = [
     "pytest>=8",
     "hypothesis>=6",


### PR DESCRIPTION
##  Reference Issue
Closes #1


##  What does this solve
This PR adds the foundational Sphinx documentation structure for `scikit-verify`. It ensures the project has clear, accessible documentation for both users and developers moving forward.


##  How
- **Created README documentation:** Added introductory guides and project overview.
- **Created public API documentation:** Documented the initial core public API, specifically focusing on the `to_sympy` function.
- **Created a design document:** Outlined the underlying philosophy and architectural decisions governing `scikit-verify`.
- **Configured Sphinx:** Set up the required Sphinx build configuration files and directory structure.


##  AI or no AI?
- [x] **AI-assisted:** 
- [x] **No AI:** Fully human-written code

