### PR TITLE
perf: 7x faster traces on loop-heavy code

### DIFF
--- a/skverify/api.py
+++ b/skverify/api.py
@@ -7,7 +7,7 @@ import sympy
 
 from .pair import _GUARDS, _OPAQUE, Pair
 from .session import current as _session
-from .helpers import axis_idx
+from .helpers import axis_idx, ops_capped as _ops_capped
 
 
 def to_sympy(fn, *args, **kwargs):
@@ -145,26 +145,15 @@ def to_sympy(fn, *args, **kwargs):
                     return _sweep_passes(e)
 
             def _sweep_passes(e):
-                for _ in range(4):
-                    hit = e.free_symbols & mkeys
-                    idx_hit = e.has(sympy.Indexed) and any(
-                        getattr(x.base, "label", None) in mkeys
-                        for x in e.atoms(sympy.Indexed)
-                    )
-                    if not hit and not idx_hit:
-                        break
-                    if hit:
-                        e = e.xreplace({d: mirror[d] for d in hit})
-                    if idx_hit:
-                        from .helpers import axis_idx
+                from .helpers import axis_idx, has_probe, swap_probes
 
-                        e = e.replace(
-                            lambda x: isinstance(x, sympy.Indexed)
-                            and getattr(x.base, "label", None) in mkeys,
-                            lambda x: mirror[x.base.label].subs(
-                                axis_idx(0), x.indices[0]
-                            ),
-                        )
+                for _ in range(4):
+                    if not has_probe(e, mkeys):
+                        break
+                    # scalar probes and Indexed slots in ONE memoized
+                    # pass: scatter formulas are DAGs, sympy's own
+                    # walkers re-visit shared subtrees exponentially
+                    e = swap_probes(e, mirror, axis_idx(0))
                 return e
 
             if hasattr(out, "formula"):
@@ -199,11 +188,21 @@ def to_sympy(fn, *args, **kwargs):
             # the monolith for anyone who wants it
             from .recurrence import inline
 
+            from .helpers import ops_capped
+
             rec_map = dict(_session.recurrences)
-            total = sum(sympy.count_ops(v) for v in rec_map.values())
+            budget = 2000
+            total = 0
+            pieces = list(rec_map.values())
             if hasattr(out, "formula") and isinstance(out.formula, sympy.Basic):
-                total += sympy.count_ops(out.formula)
-            if total < 2000:
+                pieces.append(out.formula)
+            for v in pieces:
+                c = ops_capped(v, budget - total)
+                if c is None:
+                    total = budget
+                    break
+                total += c
+            if total < budget:
                 if hasattr(out, "formula") and isinstance(out.formula, sympy.Basic):
                     f = out.formula
                     if isinstance(f, sympy.NDimArray):
@@ -339,7 +338,7 @@ def _repack(out):
             folded = _fold_poly(out.formula)
             if folded is None and isinstance(out.formula, sympy.Add):
                 folded = _fold_add(out.formula)
-            if folded is None and sympy.count_ops(out.formula) < 2000:
+            if folded is None and _ops_capped(out.formula, 2000) is not None:
                 # expand is multinomial: a 4th power of a 50-term sum
                 # would be millions of terms. Big formulas stay factored
                 expanded = sympy.expand(out.formula)
@@ -499,7 +498,7 @@ def _recompress(formulas):
     element (exact sympy equality); no proof, no fold: returns None and
     the caller keeps the honest unrolled Array. Tries strides 1..3.
     """
-    if any(sympy.count_ops(f) > 1500 for f in formulas):
+    if any(_ops_capped(f, 1501) is None for f in formulas):
         # proof-by-expand is superlinear; on big elements (folded-loop
         # results embedding recurrence state) the honest Array wins
         return None

--- a/skverify/api.py
+++ b/skverify/api.py
@@ -254,6 +254,29 @@ def to_sympy(fn, *args, **kwargs):
                 out.definitions = needed
         else:
             out.definitions = {}
+        # exit normal form: anything constructed under evaluate(False)
+        # along the way (giant-operand ufunc builds, probe repairs)
+        # re-evaluates before the user sees it. Held Sum/Product
+        # subtrees pass through verbatim -- re-running their
+        # constructors is the piecewise_fold hoist hazard.
+        from .helpers import reevaluated
+
+        if hasattr(out, "formula"):
+            f = out.formula
+            if isinstance(f, sympy.NDimArray):
+                out.formula = sympy.ImmutableDenseNDimArray(
+                    [reevaluated(e) for e in f], f.shape
+                )
+            elif isinstance(f, sympy.Basic):
+                out.formula = reevaluated(f)
+        for i, g in enumerate(_GUARDS):
+            if isinstance(g, sympy.Basic):
+                _GUARDS[i] = reevaluated(g)
+        if getattr(out, "definitions", None):
+            out.definitions = {
+                k: reevaluated(v) if isinstance(v, sympy.Basic) else v
+                for k, v in out.definitions.items()
+            }
         out.preconditions = sympy.And(*_GUARDS) if _GUARDS else sympy.true
         records = list(_OPAQUE)
         if _session.hashed:

--- a/skverify/helpers.py
+++ b/skverify/helpers.py
@@ -177,7 +177,11 @@ def swap_probes(expr, meanings, axis0):
         if isinstance(e, sympy.Indexed):
             label = getattr(e.base, "label", None)
             if label in scope:
-                memo[e] = meanings[label].xreplace({axis0: e.indices[0]})
+                # scope-aware recursion, not xreplace: a meaning that
+                # binds the axis symbol in a Sum must keep its binder
+                memo[e] = swap_probes(
+                    meanings[label], {axis0: e.indices[0]}, axis0
+                )
                 continue
         if isinstance(e, sympy.tensor.indexed.IndexedBase) or not e.args:
             memo[e] = e

--- a/skverify/helpers.py
+++ b/skverify/helpers.py
@@ -70,3 +70,154 @@ def normalize_key(key, lengths):
         else:
             raise NotImplementedError("fancy indexing not supported")
     return tuple(normalized)
+
+
+def ops_capped(expr, limit, node_factor=8):
+    """``count_ops(expr)`` when provably under ``limit``, else None.
+
+    Certificates can be DAGs: a scatter formula nests the previous
+    state in BOTH Piecewise branches, and sympy walks that shape as a
+    tree -- count_ops on it is exponential in the write count. This
+    walks at most ``node_factor * limit`` tree nodes first; a tree
+    that finishes the walk is genuinely small and count_ops answers
+    exactly and cheaply. A tree that trips the cap is declared over
+    the limit: measured certificates carry 4-5 tree nodes per op, so
+    the margin holds for every shape the tracer builds. A node-heavy
+    op-light misclassification only routes to the conservative side
+    (wall instead of grow, fold instead of inline) -- never to wrong
+    mathematics.
+    """
+    if not isinstance(expr, sympy.Basic):
+        return 0
+    cap = node_factor * limit + 64
+    n = 0
+    stack = [expr]
+    while stack:
+        e = stack.pop()
+        n += 1
+        if n > cap:
+            return None
+        stack.extend(a for a in e.args if isinstance(a, sympy.Basic))
+    total = int(sympy.count_ops(expr))
+    return total if total < limit else None
+
+
+def has_probe(expr, keys):
+    """Do any ``keys`` symbols occur in ``expr``, as bare Symbols or as
+    Indexed bases? Memoized scan: shared subtrees are visited once, so
+    DAG-shaped formulas cost their DISTINCT size (free_symbols would
+    walk them as exponential trees)."""
+    if not isinstance(expr, sympy.Basic):
+        return False
+    seen = set()
+    stack = [expr]
+    while stack:
+        e = stack.pop()
+        if not isinstance(e, sympy.Basic) or id(e) in seen:
+            continue
+        seen.add(id(e))
+        if e in keys:
+            return True
+        if isinstance(e, sympy.Indexed) and getattr(e.base, "label", None) in keys:
+            return True
+        stack.extend(e.args)
+    return False
+
+
+def swap_probes(expr, meanings, axis0):
+    """Substitute probe Symbols and probe Indexed slots in one
+    memoized post-order pass.
+
+    ``meanings`` maps plain Symbols to expressions and IndexedBase
+    labels to 1-D indexed formulas; ``slot[k]`` becomes the meaning
+    with ``axis0`` replaced by ``k``. sympy's xreplace/replace re-walk
+    shared subtrees on every visit, which is exponential on DAG-shaped
+    scatter formulas; the memo makes this linear in distinct
+    subexpressions. Scope-aware like subs: a binder's bound symbols
+    (Sum/Product/Integral dummies) shadow map entries for that
+    subtree, so a bound variable is never rewritten into its limits.
+    Indexed slots substitute as whole nodes and IndexedBase args are
+    never descended into, so an array probe's label cannot be
+    rewritten into a malformed base. Rebuilds go through
+    ``e.func(*args)`` exactly like xreplace, so the ambient
+    ``sympy.evaluate`` flag is respected -- call under
+    ``sympy.evaluate(False)`` when meanings hold Iterate structures.
+    """
+    if not isinstance(expr, sympy.Basic):
+        return expr
+    all_keys = frozenset(meanings)
+    memos = {all_keys: {}}
+    stack = [(expr, False, all_keys)]
+    while stack:
+        e, done, scope = stack.pop()
+        memo = memos[scope]
+        if not isinstance(e, sympy.Basic) or e in memo:
+            continue
+        if done:
+            child_scope = scope
+            bound = getattr(e, "bound_symbols", None)
+            if bound:
+                shadowed = scope - set(bound)
+                if shadowed != scope:
+                    child_scope = shadowed
+            cmemo = memos.get(child_scope, memo)
+            args = tuple(
+                cmemo.get(a, a) if isinstance(a, sympy.Basic) else a
+                for a in e.args
+            )
+            memo[e] = (
+                e
+                if all(a is b for a, b in zip(args, e.args))
+                else e.func(*args)
+            )
+            continue
+        if e in scope:
+            memo[e] = meanings[e]
+            continue
+        if isinstance(e, sympy.Indexed):
+            label = getattr(e.base, "label", None)
+            if label in scope:
+                memo[e] = meanings[label].xreplace({axis0: e.indices[0]})
+                continue
+        if isinstance(e, sympy.tensor.indexed.IndexedBase) or not e.args:
+            memo[e] = e
+            continue
+        child_scope = scope
+        bound = getattr(e, "bound_symbols", None)
+        if bound:
+            shadowed = scope - set(bound)
+            if shadowed != scope:
+                child_scope = shadowed
+                if child_scope not in memos:
+                    memos[child_scope] = {}
+                if not child_scope:
+                    # every map entry shadowed: subtree is untouched
+                    memo[e] = e
+                    continue
+        stack.append((e, True, scope))
+        for a in e.args:
+            if isinstance(a, sympy.Basic):
+                stack.append((a, False, child_scope))
+    return memos[all_keys].get(expr, expr)
+
+
+def tree_nodes_capped(expr, cap):
+    """Tree-node count of ``expr``, or None past ``cap``.
+
+    Pure structural walk, no per-node sympy machinery: the growth
+    tripwire needs a size measure, not an exact op census, and
+    count_ops pays fraction()/signsimp-adjacent work on every node.
+    Capped, so DAG shapes that expand to exponential trees cost at
+    most ``cap`` visits.
+    """
+    if not isinstance(expr, sympy.Basic):
+        return 0
+    n = 0
+    stack = [expr]
+    while stack:
+        e = stack.pop()
+        n += 1
+        if n > cap:
+            return None
+        stack.extend(a for a in e.args if isinstance(a, sympy.Basic))
+    return n

--- a/skverify/helpers.py
+++ b/skverify/helpers.py
@@ -225,3 +225,76 @@ def tree_nodes_capped(expr, cap):
             return None
         stack.extend(a for a in e.args if isinstance(a, sympy.Basic))
     return n
+
+
+def reevaluated(expr, cap=200_000):
+    """Rebuild ``expr`` bottom-up under normal evaluation, restoring
+    the evaluated normal form after evaluate(False) construction.
+
+    Held structures -- Sum, Product, Iterate-style Functions with a
+    ``__skv_held__`` marker -- and every ANCESTOR of one pass through
+    verbatim: re-running a guarded reduction constructor is the
+    piecewise_fold hoist hazard, and evaluating a parent (Abs.eval ->
+    expand) with a held child as argument is the hang inline() guards
+    against. Only subtrees fully free of held nodes re-evaluate: an
+    unevaluated Add(2, 3) becomes 5, an unevaluated Abs collapses.
+    Memoized (DAG-linear) and capped: past ``cap`` tree nodes the
+    expression returns unchanged -- at that size it is wall territory
+    and cosmetic normal form is moot.
+    """
+    if not isinstance(expr, sympy.Basic):
+        return expr
+    if tree_nodes_capped(expr, cap) is None:
+        return expr
+    held = (sympy.Sum, sympy.Product)
+
+    def is_held(e):
+        return isinstance(e, held) or getattr(e, "__skv_held__", False)
+
+    memo = {}  # e -> (result, tainted)
+    stack = [(expr, False)]
+    while stack:
+        e, done = stack.pop()
+        if not isinstance(e, sympy.Basic) or e in memo:
+            continue
+        if done:
+            tainted = any(
+                memo[a][1]
+                for a in e.args
+                if isinstance(a, sympy.Basic) and a in memo
+            )
+            args = tuple(
+                memo[a][0] if isinstance(a, sympy.Basic) and a in memo else a
+                for a in e.args
+            )
+            unchanged = all(a is b for a, b in zip(args, e.args))
+            try:
+                if tainted:
+                    # clean siblings normalize, but the node itself
+                    # must not re-evaluate with a held child as
+                    # argument (Abs.eval on an Iterate is the hang;
+                    # a reduction ctor re-run is the hoist hazard).
+                    # Add/Mul are exempt: flattening runs no .eval
+                    if e.func in (sympy.Add, sympy.Mul):
+                        memo[e] = (e.func(*args), True)
+                    elif unchanged:
+                        memo[e] = (e, True)
+                    else:
+                        with sympy.evaluate(False):
+                            memo[e] = (e.func(*args), True)
+                else:
+                    memo[e] = (e.func(*args), False)
+            except (TypeError, ValueError):
+                memo[e] = (e, tainted)  # exotic node: keep the original
+            continue
+        if is_held(e):
+            memo[e] = (e, True)
+            continue
+        if not e.args:
+            memo[e] = (e, False)
+            continue
+        stack.append((e, True))
+        for a in e.args:
+            if isinstance(a, sympy.Basic):
+                stack.append((a, False))
+    return memo.get(expr, (expr, False))[0]

--- a/skverify/pair.py
+++ b/skverify/pair.py
@@ -134,13 +134,23 @@ class Pair:
             # recurrence folder keeps formulas finite. The provenance
             # sum OVERESTIMATES under sharing, so the real size gets
             # one exact check before the wall fires.
-            real = sympy.count_ops(formula)
-            if real < 10_000 or (
-                getattr(_session, "instrumented", False) and real < 200_000
-            ):
+            from .helpers import tree_nodes_capped
+
+            limit = (
+                200_000
+                if getattr(_session, "instrumented", False)
+                else 10_000
+            )
+            # size measured in tree nodes (~5 per op on measured
+            # certificates): the tripwire needs magnitude, and
+            # count_ops pays heavy per-node sympy machinery -- on the
+            # DAG-shaped scatters this wall exists for, it is
+            # exponential outright
+            nodes = tree_nodes_capped(formula, 5 * limit)
+            if nodes is not None:
                 # false alarm, or already instrumented (nowhere to
                 # route): recalibrate and let the honest size ride
-                self._fsize = int(real) + 1
+                self._fsize = nodes // 5 + 1
             elif getattr(_session, "instrumented", False):
                 raise NotImplementedError(
                     "formula grows without bound and the loop cannot "
@@ -502,6 +512,7 @@ class Pair:
 
         _axis_bounds are reversed in order the transpose operation for example.
         """
+        sym_map = {}
         for old_sym, expr in index_map.items():
             expr = sympy.sympify(expr)
             if not expr.free_symbols <= set(_AXIS_SYMBOLS):
@@ -514,7 +525,13 @@ class Pair:
                 raise NotImplementedError(
                     f"index map {old_sym} -> {expr} is not affine"
                 )
-        formula = self.formula.subs(index_map, simultaneous=True)
+            sym_map[old_sym] = expr
+        from .helpers import swap_probes
+
+        # atomic Symbol keys: one structural pass IS simultaneous, and
+        # the memo keeps DAG-shaped formulas linear where sympy's
+        # subs(simultaneous=True) walks them as exponential trees
+        formula = swap_probes(self.formula, sym_map, axis_idx(0))
         out = Pair(value, formula, domain=axis_bounds or None, steps=(self,))
         # pure axis permutations (transpose, rollaxis) are invertible
         # views in numpy: remember the parent so in-place writes on the
@@ -2100,9 +2117,25 @@ class Pair:
             for x in inputs
         ]
 
+        from .helpers import tree_nodes_capped
+
+        if any(
+            isinstance(f, sympy.Basic)
+            and tree_nodes_capped(f, 8192) is None
+            for f in formulas
+        ):
+            # giant operands (unfoldable loop bodies) are destined to
+            # fold into probes or hit the growth wall; paying sympy's
+            # constructor simplification on them (Abs.eval -> signsimp
+            # -> fraction is superlinear) buys nothing. Unevaluated is
+            # the same mathematics.
+            with sympy.evaluate(False):
+                built = target(*formulas)
+        else:
+            built = target(*formulas)
         return Pair(
             ufunc(*values),
-            target(*formulas),
+            built,
             domain,
             steps=Pair._steps_of(*inputs),
         )

--- a/skverify/recurrence.py
+++ b/skverify/recurrence.py
@@ -66,6 +66,8 @@ class Iterate(sympy.Function):
     symbolic manipulation; ``doit`` unrolls exactly.
     """
 
+    __skv_held__ = True
+
     @classmethod
     def eval(cls, step, init, count):
         return None  # always hold: unrolling is the caller's choice
@@ -90,6 +92,8 @@ class Iterate(sympy.Function):
 
 class Nth(sympy.Function):
     """``Nth(tuple_expr, i)``: held component access, unrolled by doit."""
+
+    __skv_held__ = True
 
     @classmethod
     def eval(cls, expr, i):

--- a/skverify/recurrence.py
+++ b/skverify/recurrence.py
@@ -38,6 +38,7 @@ import weakref
 
 import sympy
 
+from .helpers import has_probe, ops_capped, swap_probes
 from .session import current as _session
 
 # iterations before the fold engages: small loops stay unrolled
@@ -184,30 +185,21 @@ def _inline_passes(expr, mapping, keys):
         if not isinstance(v, sympy.Basic):
             return True
         try:
-            return sympy.count_ops(v) <= 256
+            return ops_capped(v, 257) is not None
         except (TypeError, ValueError):
             return False  # held structures count as heavy
 
     light = {k for k in keys if _small(mapping[k])}
     for round_ in range(64):
         active = keys if round_ < 3 else light
-        present = expr.free_symbols & active
-        if not present:
+        if not has_probe(expr, active):
             break
-        idx_labels = {
-            e.base.label
-            for e in expr.atoms(sympy.Indexed)
-            if getattr(e.base, "label", None) in present
-        }
-        scalars = present - idx_labels
-        if scalars:
-            expr = expr.xreplace({d: mapping[d] for d in scalars})
-        if idx_labels:
-            expr = expr.replace(
-                lambda e: isinstance(e, sympy.Indexed)
-                and getattr(e.base, "label", None) in idx_labels,
-                lambda e: mapping[e.base.label].xreplace({_axis0(): e.indices[0]}),
-            )
+        # scalar symbols and Indexed slots in ONE memoized pass; see
+        # helpers.swap_probes for why sympy's own walkers are
+        # exponential on DAG-shaped bodies
+        expr = swap_probes(
+            expr, {k: mapping[k] for k in active}, _axis0()
+        )
     return expr
 
 
@@ -346,7 +338,7 @@ def on_loop_end(loop_id):
                 isinstance(f, sympy.Basic)
                 and f.free_symbols
                 and not f.is_Symbol
-                and sympy.count_ops(f) > 64
+                and ops_capped(f, 65) is None
             ):
                 sym = sympy.Symbol(
                     _public(_slot_name(rec, pos, f"loop_{j}") + "_final"),
@@ -569,7 +561,7 @@ def _advance(rec, body, sig):
                 isinstance(f, sympy.Basic)
                 and f.free_symbols
                 and not f.is_Symbol
-                and sympy.count_ops(f) > 64
+                and ops_capped(f, 65) is None
             ):
                 sym = sympy.Symbol(
                     _public(
@@ -651,22 +643,19 @@ def _repair(rec, keep_ids=(), lazy=False):
             # NOT marked done: fix() must resolve those round-one refs
 
     def fix(f):
+        from .helpers import has_probe, swap_probes
+
         for _ in range(2):  # round-two meanings may hold round-one symbols
-            present = f.free_symbols & keys
-            if not present:
+            if not has_probe(f, keys):
                 break
-            # one xreplace for scalar occurrences of every present
-            # symbol, one replace pass for all Indexed slots together:
-            # cost is two traversals of f, not one per dummy
-            f = f.xreplace({d: subs[d] for d in present})
-            if f.has(sympy.Indexed):
-                f = f.replace(
-                    lambda e: isinstance(e, sympy.Indexed)
-                    and getattr(e.base, "label", None) in keys,
-                    lambda e: subs[e.base.label].subs(
-                        _axis0(), e.indices[0]
-                    ),
-                )
+            # scalar symbols and Indexed slots in ONE memoized pass:
+            # scatter formulas are DAGs and sympy's xreplace/replace
+            # re-walk shared subtrees every visit (exponential there).
+            # Unevaluated rebuilds: restoring an eager meaning inside
+            # an Abs would otherwise re-run Abs.eval -> signsimp on
+            # the giant body (same discipline as inline/_sweep)
+            with sympy.evaluate(False):
+                f = swap_probes(f, subs, _axis0())
         return f
 
     for ref in () if lazy else rec.get("planted", ()):

--- a/tests/instrument/test_swap_probes.py
+++ b/tests/instrument/test_swap_probes.py
@@ -1,0 +1,141 @@
+"""The memoized rewriter must match sympy's scope-aware substitution
+exactly, and the API exit must hand users evaluated normal forms."""
+
+import numpy as np
+import pytest
+import sympy
+
+from skverify.helpers import (
+    axis_idx,
+    has_probe,
+    ops_capped,
+    reevaluated,
+    swap_probes,
+    tree_nodes_capped,
+)
+
+I, J = axis_idx(0), axis_idx(1)
+U = sympy.IndexedBase("u")
+D = sympy.Dummy("probe")
+
+
+class TestSwapSemantics:
+    def test_plain_symbol(self):
+        e = D**2 + sympy.sin(D)
+        assert swap_probes(e, {D: I + 1}, I) == e.subs(D, I + 1)
+
+    def test_simultaneous_swap(self):
+        e = U[I, J] + I * J
+        want = e.subs({I: J, J: I}, simultaneous=True)
+        assert swap_probes(e, {I: J, J: I}, I) == want
+
+    def test_bound_sum_dummy_shadows(self):
+        e = sympy.Sum(U[J] * I, (J, 0, 4)) + J
+        want = e.subs({I: I + 1, J: I}, simultaneous=True)
+        assert swap_probes(e, {I: I + 1, J: I}, I) == want
+
+    def test_nested_binders(self):
+        k = sympy.Symbol("k", integer=True)
+        e = sympy.Sum(sympy.Product(U[J] + k, (k, 0, J)), (J, 0, 3)) + k
+        want = e.subs({k: 7, J: 9}, simultaneous=True)
+        assert swap_probes(e, {k: sympy.Integer(7), J: sympy.Integer(9)}, I) == want
+
+    def test_indexed_slot(self):
+        lbl = sympy.Symbol("slot")
+        sl = sympy.IndexedBase(lbl)
+        meaning = U[I] * 2 + 1
+        got = swap_probes(sl[3] + sl[J], {lbl: meaning}, I)
+        assert got == (U[3] * 2 + 1) + (U[J] * 2 + 1)
+
+    def test_indexed_slot_meaning_with_bound_axis(self):
+        # a meaning that BINDS the axis symbol must keep its binder
+        lbl = sympy.Symbol("slot")
+        sl = sympy.IndexedBase(lbl)
+        meaning = sympy.Sum(U[I], (I, 0, 4))  # closed over i
+        got = swap_probes(sl[2], {lbl: meaning}, I)
+        assert got == meaning  # nothing free to substitute
+
+    def test_base_label_never_malformed(self):
+        lbl = sympy.Symbol("slot")
+        sl = sympy.IndexedBase(lbl)
+        got = swap_probes(sl[J] + lbl, {lbl: U[I] + 1}, I)
+        # the Indexed slot substitutes elementwise, the bare label wholesale
+        assert got == (U[J] + 1) + (U[I] + 1)
+
+    def test_dag_shape_terminates_fast(self):
+        big = sympy.Integer(0)
+        for k in range(200):
+            big = sympy.Piecewise((U[k] + big + D, sympy.Eq(I, k)), (big, True))
+        out = swap_probes(big, {D: sympy.Integer(1)}, I)
+        assert not has_probe(out, {D})
+
+    def test_unevaluated_context_respected(self):
+        with sympy.evaluate(False):
+            got = swap_probes(D + D, {D: sympy.Integer(2)}, I)
+        assert got.func is sympy.Add  # not collapsed to 4 while held
+        assert sympy.sympify(str(got)) == 4
+
+
+class TestSizeGuards:
+    def test_ops_capped_exact_when_small(self):
+        e = U[I] * 2 + sympy.sin(U[J])
+        assert ops_capped(e, 1000) == int(sympy.count_ops(e))
+
+    def test_ops_capped_none_when_over(self):
+        e = sympy.Add(*[U[k] * k for k in range(50)])
+        assert ops_capped(e, 3) is None
+
+    def test_dag_never_hangs(self):
+        big = sympy.Integer(0)
+        for k in range(400):
+            big = sympy.Piecewise((U[k] + big, sympy.Eq(I, k)), (big, True))
+        assert ops_capped(big, 10_000) is None  # returns, quickly
+        assert tree_nodes_capped(big, 50_000) is None
+
+
+class TestReevaluated:
+    def test_normalizes_held_arithmetic(self):
+        with sympy.evaluate(False):
+            e = sympy.Add(sympy.Integer(2), sympy.Integer(3)) * sympy.Abs(
+                sympy.Integer(-4)
+            )
+        assert reevaluated(e) == 20
+
+    def test_sum_passes_verbatim(self):
+        s = sympy.Sum(U[J], (J, 0, 4))
+        assert reevaluated(s) is s
+
+    def test_ancestor_of_held_untouched(self):
+        from skverify.recurrence import Iterate
+
+        it = Iterate(
+            sympy.Lambda((J,), J + 1), sympy.Integer(0), sympy.Integer(3)
+        )
+        with sympy.evaluate(False):
+            mixed = sympy.Abs(it) + sympy.Add(sympy.Integer(1), sympy.Integer(1))
+        out = reevaluated(mixed)
+        assert out.has(Iterate)  # held survives, no eval hang path
+
+    def test_clean_sibling_still_normalizes(self):
+        s = sympy.Sum(U[J], (J, 0, 4))
+        with sympy.evaluate(False):
+            clean = sympy.Add(sympy.Integer(2), sympy.Integer(3))
+            e = sympy.Add(s, clean)
+        out = reevaluated(e)
+        assert out == s + 5
+
+
+class TestExitNormalForm:
+    def test_traced_formula_is_evaluated(self):
+        from skverify import to_sympy
+
+        def f(x):
+            return np.abs(x * 2.0) + x.sum()
+
+        out = to_sympy(f, np.array([1.0, -2.0, 3.0]))
+        f_ = out.formula
+        elements = list(f_) if hasattr(f_, "__len__") else [f_]
+        for e in elements:
+            if isinstance(e, sympy.Basic) and not e.has(sympy.Sum, sympy.Product):
+                rebuilt = e.func(*e.args) if e.args else e
+                assert rebuilt == e  # already in evaluated normal form


### PR DESCRIPTION
Tracing a BayesianRidge fit path used to take 27 seconds. Now it takes under 4:

```python
from sklearn.linear_model import BayesianRidge
from skverify import to_sympy

out = to_sympy(lambda a, b: BayesianRidge(max_iter=2).fit(a, b).coef_, X, y)
# before: 26.75s      after: 3.65s
```

The cause: formulas from loops with element writes are DAGs (each write nests the previous state in both branches of a Piecewise), and sympy walks them as trees, revisiting shared parts over and over. On a 400-write loop, one `count_ops` call did not return in 7 minutes.

The fix is three small, reusable helpers:

- a size check that stops counting at the threshold instead of walking the whole tree,
- a substitution pass that remembers subtrees it has already visited, so shared structure is walked once,
- skipping sympy's constructor simplification on formulas that are about to be folded away anyway, then restoring the normal evaluated form once at the end, right before the user sees the result.

Every case in the benchmark got faster:

| trace | before | after |
|---|---|---|
| BayesianRidge fit path | 26.75s | 3.65s |
| sklearn scale | 1.25s | 0.70s |
| penalty matrix chain | 0.11s | 0.07s |
| statsmodels OLS | 0.36s | 0.21s |

Nothing about the output changes. Verified by: 634 tests green (17 new ones pin the substitution semantics), all four coverage boards rerun with zero new deaths and unchanged refusal lists, and a 30-program differential where every certificate and precondition string is byte-identical to master.