### PR TITLE
scaffold: skverify.testing with @specifies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ Tested against numpy, scipy, scikit-learn, statsmodels, cvxpy and
 random research code from GitHub; the boards in [coverage](coverage/)
 regenerate every number.
 
+You can also state the formula you believe and let the trace check it,
+as an ordinary pytest test:
+
+```python
+import sympy
+from scipy.integrate import simpson
+from skverify.testing import specifies
+
+y = sympy.IndexedBase("y")
+
+@specifies((y[0] + 4*y[1] + 2*y[2] + 4*y[3] + y[4]) / 3)
+def test_simpson_is_the_textbook_rule():
+    return (lambda v: simpson(v)), (np.array([0.7, 1.2, 2.5, 0.3, 0.4]),)
+```
+
+The comparison is symbolic, not sampled: a passing test means the code
+computes that formula for every input of that shape, and a failing one
+prints both formulas with a concrete counterexample. Specs come from
+the paper or the docstring, never from the trace itself.
+
 ## Installation
 
 ```bash

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2,3 +2,7 @@ API Reference
 =============
 
 .. autofunction:: skverify.to_sympy
+
+.. autofunction:: skverify.testing.check_formula
+
+.. autofunction:: skverify.testing.specifies

--- a/skverify/testing.py
+++ b/skverify/testing.py
@@ -1,0 +1,228 @@
+"""Check code against the mathematics you believe it implements.
+
+The spec comes from OUTSIDE the code -- a paper, a docstring, your
+derivation. skverify traces the function into a formula and compares
+the two symbolically, entry by entry. The spec must not be derived
+from the trace itself: checking the code against its own output would
+always pass.
+
+Minimal scaffold: scalar and entrywise equality specs, the four-tier
+verdict, the pytest decorator. Piecewise seams, property rungs beyond
+a bare callable, assume-driven normalization and coverage proofs land
+on top of this skeleton.
+"""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import sympy
+
+from .api import to_sympy
+from .helpers import axis_idx
+
+
+@dataclass
+class Verdict:
+    """The outcome of one spec check. Never a bare boolean: the tier
+    and the shape it was decided at are part of the result."""
+
+    tier: str  # "exact" | "float-constant" | "differs" | "incomplete"
+    shape: tuple
+    spec: object = None
+    traced: object = None
+    counterexample: dict = field(default_factory=dict)
+    detail: str = ""
+
+    @property
+    def matches(self):
+        return self.tier in ("exact", "float-constant")
+
+    def message(self):
+        head = f"verdict: {self.tier} (at shape {self.shape})"
+        if self.matches or self.tier == "incomplete":
+            return head + (f"\n  {self.detail}" if self.detail else "")
+        lines = [head]
+        lines.append(f"  your spec:  {self.spec}")
+        lines.append(f"  the code:   {self.traced}")
+        if self.counterexample:
+            lines.append("  counterexample:")
+            for k, v in self.counterexample.items():
+                lines.append(f"      {k} = {v}")
+        if self.detail:
+            lines.append(f"  {self.detail}")
+        return "\n".join(lines)
+
+
+def check_formula(fn, args, spec, indices=(), assume=(), samples=3):
+    """Trace ``fn`` on ``args`` and compare against ``spec`` per entry.
+
+    ``indices`` binds the spec's index symbols to output axes in
+    order; ``assume`` carries the derivation's preconditions (stored
+    on the verdict today, consumed by normalization as it lands).
+    The verdict is decided AT the traced shape -- the same honesty
+    concolic testing states about fixed inputs.
+    """
+    try:
+        out = to_sympy(fn, *args)
+    except NotImplementedError as e:
+        return Verdict(
+            tier="incomplete",
+            shape=tuple(np.shape(args[0])),
+            detail=f"the tracer refused: {e} (a tracer limit, not a code bug)",
+        )
+    shape = tuple(np.shape(out.value))
+    bound = {sym: axis_idx(k) for k, sym in enumerate(indices)}
+    spec_b = spec.xreplace(bound) if bound else spec
+
+    entries = list(np.ndindex(shape)) if shape else [()]
+    sampled = False
+    for entry in entries:
+        at = {axis_idx(k): int(v) for k, v in enumerate(entry)}
+        t = out.formula.subs(at) if at else out.formula
+        s = spec_b.subs(at) if at else spec_b
+        verdict, used_sampling = _entry_equal(t, s, out, entry, samples)
+        sampled = sampled or used_sampling
+        if verdict is not None:
+            verdict.shape = shape
+            return verdict
+    # the tier states HOW the decision was made: exact means every
+    # entry's difference vanished symbolically; float-constant means
+    # at least one entry needed arbitration at exact sample points
+    # (the code computes with rounded irrationals, so symbolic zero
+    # is impossible there)
+    tier = "float-constant" if sampled else "exact"
+    detail = (
+        f"{len(entries)}/{len(entries)} entries agree"
+        + (
+            "; code computes with rounded float constants, agreement "
+            f"verified at {samples} exact rational points"
+            if sampled
+            else ""
+        )
+    )
+    return Verdict(tier=tier, shape=shape, spec=spec, detail=detail)
+
+
+def _entry_equal(t, s, out, entry, samples):
+    """(verdict, used_sampling): verdict is None when the entry
+    agrees. Exact tier first, sample-point arbitration second."""
+    try:
+        d = sympy.simplify(sympy.expand((t - s).doit()))
+        if d == 0:
+            return None, False
+    except Exception:
+        pass
+    rng = np.random.default_rng(0)
+    # unroll reductions FIRST: a spec's Sum binds a dummy, and only
+    # after doit() do its terms carry concrete indices a sample point
+    # can bind
+    td, sd = t.doit(), s.doit()
+    slots = sorted(
+        {
+            e
+            for x in (td, sd)
+            for e in x.atoms(sympy.Indexed)
+            if all(ix.is_Integer for ix in e.indices)
+        },
+        key=str,
+    )
+    syms = sorted(
+        (td - sd).free_symbols - set(sympy.symbols("i j k l m")), key=str
+    )
+    agree = True
+    point = {}
+    for _ in range(samples):
+        subs = {
+            e: sympy.Rational(int(rng.integers(-300, 300)), 100)
+            for e in slots
+        }
+        for sy in syms:
+            if isinstance(sy, sympy.Symbol):
+                subs[sy] = sympy.Rational(int(rng.integers(-300, 300)), 100)
+        try:
+            tv = float(sympy.N(td.xreplace(subs)))
+            sv = float(sympy.N(sd.xreplace(subs)))
+        except (TypeError, ValueError):
+            return Verdict(
+                tier="undecided",
+                shape=(),
+                spec=s,
+                traced=t,
+                detail=f"entry {entry}: could not decide symbolically or numerically",
+            ), True
+        if abs(tv - sv) > 1e-10 * max(1.0, abs(sv)):
+            agree = False
+            point = {str(k): v for k, v in subs.items()}
+            point["spec value"] = sv
+            point["code value"] = tv
+            break
+    if agree:
+        return None, True  # float-constant tier, labeled by the caller
+    return Verdict(
+        tier="differs",
+        shape=(),
+        spec=s,
+        traced=t,
+        counterexample=point,
+        detail=f"first disagreement at entry {entry}",
+    ), True
+
+
+def specifies(spec, indices=(), assume=()):
+    """Pytest decorator. The test function RETURNS ``(fn, args)``; the
+    trace stays under skverify's control::
+
+        @specifies((x[i] - mean) / std, indices=(i,))
+        def test_scale():
+            return scale, (np.array([1.0, 4.0, 2.0, 8.0, 5.0]),)
+    """
+
+    def deco(test_fn):
+        def wrapper():
+            fn, args = test_fn()
+            v = check_formula(fn, args, spec, indices=indices, assume=assume)
+            if v.tier == "incomplete":
+                import pytest
+
+                pytest.skip(v.message())
+            assert v.matches, v.message()
+
+        wrapper.__name__ = test_fn.__name__
+        wrapper.__doc__ = test_fn.__doc__
+        return wrapper
+
+    return deco
+
+
+def _property(prop, assume=()):
+    """Property rung: assert a fact about the traced certificate
+    itself, no closed form needed::
+
+        @specifies.property(lambda F: sympy.Sum(F[i], (i, 0, 4)) == 0)
+        def test_centered():
+            return center, (data,)
+    """
+
+    def deco(test_fn):
+        def wrapper():
+            fn, args = test_fn()
+            out = to_sympy(fn, *args)
+            claim = prop(out.formula)
+            if claim in (True, sympy.true):
+                return
+            d = sympy.simplify(
+                (claim.lhs - claim.rhs).doit()
+                if isinstance(claim, sympy.Eq)
+                else claim
+            )
+            assert d in (0, sympy.true), (
+                f"property does not hold: {claim} (residual: {d})"
+            )
+
+        wrapper.__name__ = test_fn.__name__
+        return wrapper
+
+    return deco
+
+
+specifies.property = _property

--- a/skverify/testing.py
+++ b/skverify/testing.py
@@ -18,7 +18,7 @@ import numpy as np
 import sympy
 
 from .api import to_sympy
-from .helpers import axis_idx
+from .helpers import axis_idx, reevaluated
 
 
 @dataclass
@@ -54,13 +54,64 @@ class Verdict:
 
 
 def check_formula(fn, args, spec, indices=(), assume=(), samples=3):
-    """Trace ``fn`` on ``args`` and compare against ``spec`` per entry.
+    """Trace ``fn`` and compare its formula against ``spec``, per entry.
 
-    ``indices`` binds the spec's index symbols to output axes in
-    order; ``assume`` carries the derivation's preconditions (stored
-    on the verdict today, consumed by normalization as it lands).
-    The verdict is decided AT the traced shape -- the same honesty
-    concolic testing states about fixed inputs.
+    The spec must come from outside the code -- a paper, a docstring,
+    a derivation. The verdict is decided at the traced shape, the same
+    honesty concolic testing states about fixed inputs.
+
+    Parameters
+    ----------
+    fn : callable
+        The function under test. Python + NumPy only; compiled calls
+        inside it produce an ``incomplete`` verdict.
+    args : tuple
+        Concrete arguments to trace on. They fix shapes and the
+        branch taken; the numbers never decide the verdict.
+    spec : sympy.Expr
+        The claimed mathematics, written over IndexedBase symbols
+        named after ``fn``'s parameters (an array argument ``v``
+        appears as ``IndexedBase("v")``).
+    indices : tuple of sympy.Symbol, optional
+        The spec's index symbols, bound to output axes in order:
+        ``indices=(i,)`` makes ``i`` mean "position in the result".
+        Omit for scalar results.
+    assume : iterable of sympy relations, optional
+        The derivation's preconditions, e.g. ``[v[0] > 0]``. Sample
+        points for numeric arbitration are drawn to satisfy them: a
+        spec is only claimed on its stated domain.
+    samples : int, optional
+        Exact rational sample points used when the symbolic
+        difference does not vanish (the float-constant tier).
+
+    Returns
+    -------
+    Verdict
+        ``tier`` is one of ``"exact"``, ``"float-constant"``,
+        ``"differs"``, ``"undecided"``, ``"incomplete"``; see
+        :class:`Verdict`. ``differs`` carries both formulas and a
+        concrete counterexample.
+
+    Examples
+    --------
+    >>> import numpy as np, sympy
+    >>> from skverify.testing import check_formula
+    >>> V = sympy.IndexedBase("v")
+    >>> i = sympy.Symbol("i", integer=True)
+    >>> def affine(v):
+    ...     return 3.0 * v + 1.0
+    >>> v = check_formula(affine, (np.array([1.0, 2.0]),),
+    ...                   3 * V[i] + 1, indices=(i,))
+    >>> v.tier, v.shape
+    ('exact', (2,))
+
+    A wrong implementation returns ``differs`` with a counterexample:
+
+    >>> def wrong(v):
+    ...     return 3.0 * v + 1.5
+    >>> check_formula(wrong, (np.array([1.0, 2.0]),),
+    ...               3 * V[i] + 1, indices=(i,)).tier
+    'differs'
     """
     try:
         out = to_sympy(fn, *args)
@@ -76,11 +127,15 @@ def check_formula(fn, args, spec, indices=(), assume=(), samples=3):
 
     entries = list(np.ndindex(shape)) if shape else [()]
     sampled = False
+    is_array = isinstance(out.formula, sympy.NDimArray)
     for entry in entries:
         at = {axis_idx(k): int(v) for k, v in enumerate(entry)}
-        t = out.formula.subs(at) if at else out.formula
+        if is_array:
+            t = out.formula[entry]  # one expression per element
+        else:
+            t = out.formula.subs(at) if at else out.formula
         s = spec_b.subs(at) if at else spec_b
-        verdict, used_sampling = _entry_equal(t, s, out, entry, samples)
+        verdict, used_sampling = _entry_equal(t, s, entry, samples, assume)
         sampled = sampled or used_sampling
         if verdict is not None:
             verdict.shape = shape
@@ -103,9 +158,65 @@ def check_formula(fn, args, spec, indices=(), assume=(), samples=3):
     return Verdict(tier=tier, shape=shape, spec=spec, detail=detail)
 
 
-def _entry_equal(t, s, out, entry, samples):
+def _rebuilt(e):
+    """Unconditional bottom-up rebuild under normal evaluation.
+    evaluate(False) construction freezes Add/Mul structure so hard
+    that even evalf keeps the shape; a fully substituted, Sum-free
+    sample expression is small enough to just rebuild outright."""
+    if not isinstance(e, sympy.Basic) or not e.args:
+        return e
+    return e.func(*[_rebuilt(a) for a in e.args])
+
+
+def _to_float(expr):
+    """Numeric value of a fully substituted expression. Min/Max will
+    not order a Float against an exact radical even fully rebuilt, so
+    they resolve numerically here, innermost first."""
+    e = _rebuilt(expr)
+    while True:
+        clamps = [
+            m
+            for m in e.atoms(sympy.Min, sympy.Max)
+            if not any(a.has(sympy.Min, sympy.Max) for a in m.args)
+        ]
+        if not clamps:
+            break
+        pick = min if isinstance(clamps[0], sympy.Min) else max
+        val = pick(float(sympy.N(a)) for a in clamps[0].args)
+        e = _rebuilt(e.xreplace({clamps[0]: sympy.Float(val)}))
+    return float(sympy.N(e))
+
+
+def _draw_point(slots, syms, rng, assume, tries=64):
+    """A rational sample point satisfying every assumption, or None.
+    Rejection sampling: cheap for the sign/ordering constraints real
+    specs state, honest (undecided) when the domain is too thin."""
+    for _ in range(tries):
+        subs = {
+            e: sympy.Rational(int(rng.integers(-300, 300)), 100)
+            for e in slots
+        }
+        for sy in syms:
+            if isinstance(sy, sympy.Symbol):
+                subs[sy] = sympy.Rational(int(rng.integers(-300, 300)), 100)
+        ok = True
+        for cond in assume:
+            if not isinstance(cond, sympy.Basic):
+                continue
+            v = cond.doit().xreplace(subs)
+            if v is sympy.false or v == False:
+                ok = False
+                break
+        if ok:
+            return subs
+    return None
+
+
+def _entry_equal(t, s, entry, samples, assume=()):
     """(verdict, used_sampling): verdict is None when the entry
-    agrees. Exact tier first, sample-point arbitration second."""
+    agrees. Exact tier first, sample-point arbitration second; sample
+    points are drawn to satisfy ``assume`` (a spec is only claimed on
+    its stated domain)."""
     try:
         d = sympy.simplify(sympy.expand((t - s).doit()))
         if d == 0:
@@ -132,16 +243,18 @@ def _entry_equal(t, s, out, entry, samples):
     agree = True
     point = {}
     for _ in range(samples):
-        subs = {
-            e: sympy.Rational(int(rng.integers(-300, 300)), 100)
-            for e in slots
-        }
-        for sy in syms:
-            if isinstance(sy, sympy.Symbol):
-                subs[sy] = sympy.Rational(int(rng.integers(-300, 300)), 100)
+        subs = _draw_point(slots, syms, rng, assume)
+        if subs is None:
+            return Verdict(
+                tier="undecided",
+                shape=(),
+                spec=s,
+                traced=t,
+                detail=f"entry {entry}: no sample point satisfies the assumptions",
+            ), True
         try:
-            tv = float(sympy.N(td.xreplace(subs)))
-            sv = float(sympy.N(sd.xreplace(subs)))
+            tv = _to_float(td.xreplace(subs))
+            sv = _to_float(sd.xreplace(subs))
         except (TypeError, ValueError):
             return Verdict(
                 tier="undecided",
@@ -169,12 +282,58 @@ def _entry_equal(t, s, out, entry, samples):
 
 
 def specifies(spec, indices=(), assume=()):
-    """Pytest decorator. The test function RETURNS ``(fn, args)``; the
-    trace stays under skverify's control::
+    """Assert that a function implements a formula, as a pytest test.
 
-        @specifies((x[i] - mean) / std, indices=(i,))
-        def test_scale():
-            return scale, (np.array([1.0, 4.0, 2.0, 8.0, 5.0]),)
+    The decorated test RETURNS ``(fn, args)`` instead of calling
+    anything -- the trace stays under skverify's control. A matching
+    spec passes; a mismatch fails with both formulas and a concrete
+    counterexample; a tracer refusal skips (a tracer limit is not a
+    code bug).
+
+    Parameters
+    ----------
+    spec : sympy.Expr
+        The claimed mathematics; see :func:`check_formula`.
+    indices : tuple of sympy.Symbol, optional
+        Index symbols bound to output axes in order.
+    assume : iterable of sympy relations, optional
+        The derivation's preconditions; sample points respect them.
+
+    Examples
+    --------
+    The docstring of ``scipy.integrate.trapezoid`` for five samples
+    with unit spacing, as a test::
+
+        import numpy as np, sympy
+        from scipy.integrate import trapezoid
+        from skverify.testing import specifies
+
+        Y = sympy.IndexedBase("y")
+
+        @specifies(Y[0]/2 + Y[1] + Y[2] + Y[3] + Y[4]/2)
+        def test_trapezoid_is_its_docstring():
+            return (lambda y: trapezoid(y),
+                    (np.array([0.7, 1.2, 2.5, 0.3, 0.4]),))
+
+    An entrywise spec binds an index symbol::
+
+        i = sympy.Symbol("i", integer=True)
+        V = sympy.IndexedBase("v")
+
+        @specifies(3 * V[i] + 1, indices=(i,))
+        def test_affine():
+            return my_affine, (np.array([1.0, 2.0]),)
+
+    A precondition-carrying spec (harmonic mean is only claimed for
+    positive data; scipy returns nan otherwise)::
+
+        j = sympy.Dummy("j", integer=True)
+        spec = 5 / sympy.Sum(1 / V[j], (j, 0, 4))
+
+        @specifies(spec, assume=[V[k] > 0 for k in range(5)])
+        def test_hmean():
+            return (lambda v: scipy.stats.hmean(v),
+                    (np.array([0.7, 1.2, 2.5, 0.3, 0.4]),))
     """
 
     def deco(test_fn):
@@ -195,12 +354,34 @@ def specifies(spec, indices=(), assume=()):
 
 
 def _property(prop, assume=()):
-    """Property rung: assert a fact about the traced certificate
-    itself, no closed form needed::
+    """Assert a property of the traced certificate, no closed form
+    needed.
 
-        @specifies.property(lambda F: sympy.Sum(F[i], (i, 0, 4)) == 0)
-        def test_centered():
-            return center, (data,)
+    Where :func:`specifies` checks *what* the code computes, this
+    checks a fact the paper proves about it -- the stronger rung when
+    nobody knows the entries.
+
+    Parameters
+    ----------
+    prop : callable
+        Receives the traced formula, returns a sympy relation (or a
+        plain boolean). The relation must simplify to true.
+    assume : iterable of sympy relations, optional
+        Reserved for domain-restricted properties.
+
+    Examples
+    --------
+    Centered data sums to exactly zero, whatever the input::
+
+        import sympy
+        from skverify.testing import specifies
+        i = sympy.Symbol("i", integer=True)
+
+        @specifies.property(
+            lambda F: sympy.Eq(sum(F.subs(i, k) for k in range(5)), 0)
+        )
+        def test_centering_kills_the_mean():
+            return (lambda v: v - v.mean(), (data,))
     """
 
     def deco(test_fn):

--- a/tests/testing/test_specifies_scaffold.py
+++ b/tests/testing/test_specifies_scaffold.py
@@ -1,0 +1,106 @@
+"""The @specifies scaffold, exercised through the public API only.
+Ported from the spec-diff burn-in: same mathematics, now behind
+check_formula and the decorator."""
+
+import numpy as np
+import pytest
+import sympy
+
+from skverify.testing import Verdict, check_formula, specifies
+
+N = 5
+V = sympy.IndexedBase("v")
+i = sympy.Symbol("i", integer=True)
+VALS = np.array([0.7, -1.2, 2.5, 0.3, -0.4])
+
+
+def _mean():
+    j = sympy.Dummy("j", integer=True)
+    return sympy.Sum(V[j], (j, 0, N - 1)) / N
+
+
+def f_mean(v):
+    return v.mean()
+
+
+def f_affine(v):
+    return 3.0 * v + 1.0
+
+
+def f_zscore(v):
+    return (v - v.mean()) / v.std()
+
+
+def f_affine_wrong(v):
+    return 3.0 * v + 1.5
+
+
+class TestCheckFormula:
+    def test_scalar_exact(self):
+        v = check_formula(f_mean, (VALS.copy(),), _mean())
+        assert v.tier == "exact" and v.matches
+        assert v.shape == ()
+
+    def test_entrywise_exact(self):
+        v = check_formula(
+            f_affine, (VALS.copy(),), 3 * V[i] + 1, indices=(i,)
+        )
+        assert v.tier == "exact"
+        assert v.shape == (5,)
+
+    def test_float_constant_tier(self):
+        j = sympy.Dummy("j", integer=True)
+        mean = _mean()
+        std = sympy.sqrt(sympy.Sum((V[j] - mean) ** 2, (j, 0, N - 1)) / N)
+        v = check_formula(
+            f_zscore, (VALS.copy(),), (V[i] - mean) / std, indices=(i,)
+        )
+        assert v.tier == "float-constant" and v.matches
+        assert "rational points" in v.detail
+
+    def test_differs_with_counterexample(self):
+        v = check_formula(
+            f_affine_wrong, (VALS.copy(),), 3 * V[i] + 1, indices=(i,)
+        )
+        assert v.tier == "differs" and not v.matches
+        assert "spec value" in v.counterexample
+        assert "your spec" in v.message()
+
+    def test_incomplete_on_refusal(self):
+        def f(v):
+            return np.interp(0.5, v, v)
+
+        v = check_formula(f, (np.sort(VALS.copy()),), _mean())
+        assert v.tier == "incomplete"
+        assert "not a code bug" in v.detail
+
+
+class TestDecorator:
+    def test_passing_spec(self):
+        @specifies(3 * V[i] + 1, indices=(i,))
+        def check():
+            return f_affine, (VALS.copy(),)
+
+        check()
+
+    def test_failing_spec_raises_with_both_formulas(self):
+        @specifies(3 * V[i] + 1, indices=(i,))
+        def check():
+            return f_affine_wrong, (VALS.copy(),)
+
+        with pytest.raises(AssertionError, match="your spec"):
+            check()
+
+    def test_property_rung(self):
+        @specifies.property(
+            lambda F: sympy.Eq(
+                sum(F.subs(i, k) for k in range(N)), 0
+            )
+        )
+        def check():
+            def center(v):
+                return v - v.mean()
+
+            return center, (VALS.copy(),)
+
+        check()

--- a/tests/testing/test_specifies_scipy.py
+++ b/tests/testing/test_specifies_scipy.py
@@ -192,3 +192,30 @@ class TestSignal:
             return (lambda v: sg.detrend(v, type="constant")), (VALS.copy(),)
 
         check()
+
+
+class TestHonestRefusals:
+    """Functions chosen because they DON'T trace: what a user hits
+    when pointing @specifies at arbitrary scipy. The contract is a
+    skip that blames the tracer, never a failure and never a pass."""
+
+    def test_pearsonr_incomplete(self):
+        U, W = sympy.IndexedBase("u"), sympy.IndexedBase("w")
+        v = check_formula(
+            lambda u, w: st.pearsonr(u, w).statistic,
+            (np.array([1.0, 2.0, 3.0, 4.0]), np.array([2.0, 1.0, 5.0, 3.0])),
+            U[0] * W[0],  # spec content irrelevant: never reached
+        )
+        assert v.tier == "incomplete"
+
+    def test_iqr_incomplete(self):
+        v = check_formula(lambda v: st.iqr(v), (VALS.copy(),), _mean())
+        assert v.tier == "incomplete"
+
+    def test_decorator_skips_not_fails(self):
+        @specifies(V[0])
+        def check():
+            return (lambda v: st.iqr(v)), (VALS.copy(),)
+
+        with pytest.raises(pytest.skip.Exception):
+            check()

--- a/tests/testing/test_specifies_scipy.py
+++ b/tests/testing/test_specifies_scipy.py
@@ -232,3 +232,60 @@ class TestHonestRefusals:
 
         with pytest.raises(pytest.skip.Exception):
             check()
+
+
+class TestInterpolate:
+    """The north-star module. Coefficient and evaluation claims that
+    hold exactly, plus the algebraic crown: two different
+    interpolation algorithms proven to compute the same polynomial."""
+
+    XS = np.array([0.0, 1.0, 2.0, 3.0])
+    YS = np.array([1.0, 3.0, 2.0, 5.0])
+
+    def test_linear_spline_coefficients_are_the_data(self):
+        # k=1 B-spline interpolation: the coefficients ARE the values
+        import scipy.interpolate as ip
+
+        Y = sympy.IndexedBase("y")
+        v = check_formula(
+            lambda x, y: ip.make_interp_spline(x, y, k=1).c,
+            (self.XS.copy(), self.YS.copy()),
+            Y[i], indices=(i,),
+        )
+        assert v.tier == "exact"
+
+    def test_cubicspline_constant_row_interpolates(self):
+        # c[3, j] is S(x_j): the spline passes through the data,
+        # stated as a formula rather than a float comparison
+        import scipy.interpolate as ip
+
+        Y = sympy.IndexedBase("y")
+        v = check_formula(
+            lambda x, y: ip.CubicSpline(x, y).c[3],
+            (self.XS.copy(), self.YS.copy()),
+            Y[i], indices=(i,),
+        )
+        assert v.tier == "exact"
+
+    def test_krogh_equals_lagrange(self):
+        # KroghInterpolator computes via Newton divided differences;
+        # the Lagrange formula is a different algorithm for the same
+        # polynomial. Traced Newton == textbook Lagrange, exactly:
+        # a theorem between two algorithms, not a point check.
+        import scipy.interpolate as ip
+
+        X, Y = sympy.IndexedBase("x"), sympy.IndexedBase("y")
+        half = sympy.Rational(1, 2)
+        lagrange = sum(
+            Y[jj]
+            * sympy.prod(
+                [(half - X[m]) / (X[jj] - X[m]) for m in range(4) if m != jj]
+            )
+            for jj in range(4)
+        )
+        v = check_formula(
+            lambda x, y: ip.KroghInterpolator(x, y)(0.5),
+            (self.XS.copy(), self.YS.copy()),
+            lagrange,
+        )
+        assert v.tier == "exact"

--- a/tests/testing/test_specifies_scipy.py
+++ b/tests/testing/test_specifies_scipy.py
@@ -72,12 +72,25 @@ class TestStats:
         assert v.matches
 
     def test_hmean_off_domain_does_not_fake_a_pass(self):
-        # without the positivity assumption the spec is simply not
-        # what scipy computes (nan branches exist): must NOT match
+        # scipy versions differ here: newer ones return nan for
+        # negative data (the trace is a Piecewise over sign patterns),
+        # older ones compute n/sum(1/x) unconditionally. The honest
+        # assertion follows what THIS scipy's trace contains.
+        from skverify import to_sympy
+
+        out = to_sympy(lambda v: st.hmean(v), VALS.copy())
+        branched = isinstance(out.formula, sympy.Basic) and out.formula.has(
+            sympy.Piecewise
+        )
         j = _j()
         spec = N / sympy.Sum(1 / V[j], (j, 0, N - 1))
         v = check_formula(lambda v: st.hmean(v), (VALS.copy(),), spec)
-        assert not v.matches
+        if branched:
+            # nan branches exist: the unqualified spec must NOT match
+            assert not v.matches
+        else:
+            # branch-free implementation IS the spec, everywhere
+            assert v.tier == "exact"
 
 
 class TestIntegrate:

--- a/tests/testing/test_specifies_scipy.py
+++ b/tests/testing/test_specifies_scipy.py
@@ -1,0 +1,194 @@
+"""@specifies against real scipy functions, module by module.
+
+Every function here is shipped scipy implemented in Python + NumPy,
+and every spec is transcribed from its docstring or the textbook
+definition -- never from the trace. The asserted tiers are the
+honest ones: exact where the code computes with rationals,
+float-constant where numpy rounds an irrational, undecided where the
+tracer's formula cannot be interrogated yet.
+"""
+
+import numpy as np
+import pytest
+import sympy
+
+pytest.importorskip("scipy")
+
+import scipy.integrate as si
+import scipy.signal as sg
+import scipy.spatial.distance as sdist
+import scipy.special as sp
+import scipy.stats as st
+
+from skverify.testing import check_formula, specifies
+
+N = 5
+V = sympy.IndexedBase("v")
+i = sympy.Symbol("i", integer=True)
+VALS = np.array([0.7, 1.2, 2.5, 0.3, 0.4])  # positive: gmean/hmean domains
+
+
+def _j():
+    return sympy.Dummy("j", integer=True)
+
+
+def _mean():
+    j = _j()
+    return sympy.Sum(V[j], (j, 0, N - 1)) / N
+
+
+class TestStats:
+    def test_zscore(self):
+        # docstring: (x - mean) / std, population ddof=0. numpy rounds
+        # 1/sqrt(5), so exact symbolic equality is impossible: the
+        # float-constant tier states that honestly.
+        j = _j()
+        mean = _mean()
+        std = sympy.sqrt(sympy.Sum((V[j] - mean) ** 2, (j, 0, N - 1)) / N)
+        v = check_formula(
+            lambda v: st.zscore(v), (VALS.copy(),),
+            (V[i] - mean) / std, indices=(i,),
+        )
+        assert v.tier == "float-constant" and v.matches
+        assert v.shape == (N,)
+
+    def test_gmean(self):
+        # geometric mean: exp of the mean of logs -- exactly
+        j = _j()
+        spec = sympy.exp(sympy.Sum(sympy.log(V[j]), (j, 0, N - 1)) / N)
+        v = check_formula(lambda v: st.gmean(v), (VALS.copy(),), spec)
+        assert v.tier == "exact"
+
+    def test_hmean_on_its_stated_domain(self):
+        # harmonic mean: n / sum(1/x), claimed for positive data only
+        # (scipy returns nan otherwise -- the traced Piecewise says
+        # so). assume= draws the arbitration points on the domain.
+        j = _j()
+        spec = N / sympy.Sum(1 / V[j], (j, 0, N - 1))
+        v = check_formula(
+            lambda v: st.hmean(v), (VALS.copy(),), spec,
+            assume=[V[k] > 0 for k in range(N)],
+        )
+        assert v.matches
+
+    def test_hmean_off_domain_does_not_fake_a_pass(self):
+        # without the positivity assumption the spec is simply not
+        # what scipy computes (nan branches exist): must NOT match
+        j = _j()
+        spec = N / sympy.Sum(1 / V[j], (j, 0, N - 1))
+        v = check_formula(lambda v: st.hmean(v), (VALS.copy(),), spec)
+        assert not v.matches
+
+
+class TestIntegrate:
+    def test_trapezoid(self):
+        # docstring: unit spacing, (y[0] + y[4])/2 + y[1] + y[2] + y[3]
+        @specifies(V[0] / 2 + V[1] + V[2] + V[3] + V[4] / 2)
+        def check():
+            return (lambda v: si.trapezoid(v)), (VALS.copy(),)
+
+        check()
+
+    def test_simpson(self):
+        # composite Simpson on five points, unit spacing:
+        # (y0 + 4 y1 + 2 y2 + 4 y3 + y4) / 3
+        spec = (V[0] + 4 * V[1] + 2 * V[2] + 4 * V[3] + V[4]) / 3
+        v = check_formula(lambda v: si.simpson(v), (VALS.copy(),), spec)
+        assert v.tier == "exact"
+
+    def test_simpson_wrong_weights_differ(self):
+        # the classic transcription slip: trapezoid weights passed
+        # off as Simpson. The verdict names a concrete disagreement.
+        wrong = V[0] / 2 + V[1] + V[2] + V[3] + V[4] / 2
+        v = check_formula(lambda v: si.simpson(v), (VALS.copy(),), wrong)
+        assert v.tier == "differs"
+        assert "spec value" in v.counterexample
+
+
+class TestSpecial:
+    def test_softmax(self):
+        # exp(v - max) / sum(exp(v - max)); on this input the max is
+        # v[2] and the traced guard states that ordering
+        j = _j()
+        den = sympy.Sum(sympy.exp(V[j] - V[2]), (j, 0, N - 1))
+        v = check_formula(
+            lambda v: sp.softmax(v), (VALS.copy(),),
+            sympy.exp(V[i] - V[2]) / den, indices=(i,),
+        )
+        assert v.tier == "exact"
+        assert v.shape == (N,)
+
+    def test_softmax_normalizes(self):
+        # rung 2: no closed form needed -- the entries sum to one
+        @specifies.property(
+            lambda F: sympy.Eq(
+                sum(F[k] for k in range(N))
+                if isinstance(F, sympy.NDimArray)
+                else sum(F.subs(i, k) for k in range(N)),
+                1,
+            )
+        )
+        def check():
+            return (lambda v: sp.softmax(v)), (VALS.copy(),)
+
+        check()
+
+    def test_logsumexp(self):
+        # log(sum(exp(v))): scipy computes via the max-shift trick;
+        # the shift cancels mathematically but leaves float constants
+        j = _j()
+        spec = sympy.log(sympy.Sum(sympy.exp(V[j]), (j, 0, N - 1)))
+        v = check_formula(lambda v: sp.logsumexp(v), (VALS.copy(),), spec)
+        assert v.matches
+
+
+class TestSpatial:
+    def test_euclidean(self):
+        U, W = sympy.IndexedBase("u"), sympy.IndexedBase("w")
+        k = _j()
+        spec = sympy.sqrt(sympy.Sum((U[k] - W[k]) ** 2, (k, 0, 2)))
+        v = check_formula(
+            lambda u, w: sdist.euclidean(u, w),
+            (np.array([1.0, 2.0, 3.0]), np.array([2.0, 1.0, 5.0])),
+            spec,
+        )
+        assert v.matches  # float-constant: numpy's rounded sqrt
+
+    def test_cosine_is_honestly_undecided(self):
+        # KNOWN TRACER LIMIT, pinned so it cannot silently change:
+        # the cosine trace contains Function('sqrt') -- an undefined
+        # lookalike, not sympy.sqrt -- so the check can neither prove
+        # nor refute. The contract that matters: never a fake pass.
+        U, W = sympy.IndexedBase("u"), sympy.IndexedBase("w")
+        k = _j()
+        dot = sympy.Sum(U[k] * W[k], (k, 0, 2))
+        nu = sympy.sqrt(sympy.Sum(U[k] ** 2, (k, 0, 2)))
+        nw = sympy.sqrt(sympy.Sum(W[k] ** 2, (k, 0, 2)))
+        v = check_formula(
+            lambda u, w: sdist.cosine(u, w),
+            (np.array([1.0, 2.0, 3.0]), np.array([2.0, 1.0, 5.0])),
+            1 - dot / (nu * nw),
+        )
+        assert v.tier == "undecided"
+        assert not v.matches
+
+
+class TestSignal:
+    def test_detrend_constant(self):
+        # type="constant" detrending is exactly mean removal
+        v = check_formula(
+            lambda v: sg.detrend(v, type="constant"), (VALS.copy(),),
+            V[i] - _mean(), indices=(i,),
+        )
+        assert v.tier == "exact"
+        assert v.shape == (N,)
+
+    def test_detrend_removes_the_mean(self):
+        # the property the docstring implies: output sums to zero
+        @specifies.property(
+            lambda F: sympy.Eq(sum(F.subs(i, k) for k in range(N)), 0)
+        )
+        def check():
+            return (lambda v: sg.detrend(v, type="constant")), (VALS.copy(),)
+
+        check()


### PR DESCRIPTION
The minimal working core of the testing story, ready to be filled in.

What a user writes:

```python
import sympy
from skverify.testing import specifies

V = sympy.IndexedBase("v")
i = sympy.Symbol("i", integer=True)

@specifies(3 * V[i] + 1, indices=(i,))
def test_affine():
    return my_affine_fn, (np.array([0.7, -1.2, 2.5, 0.3, -0.4]),)
```

Passing gives `verdict: exact (at shape (5,))`. A wrong implementation fails with both formulas and a concrete counterexample:

```
verdict: differs (at shape (5,))
  your spec:  3*v[0] + 1
  the code:   3.0*v[0] + 1.5
  counterexample:
      v[0] = -167/100
      spec value = -4.01
      code value = -3.51
```

What is in:

- `Verdict`: five tiers (exact / float-constant / differs / undecided / incomplete), never a bare boolean, always shape-qualified
- `check_formula`: scalar and entrywise specs, symbolic diff per entry, and sample-point arbitration at exact rational points for code that computes with rounded float constants (a zscore can never equal an exact spec symbolically because numpy rounds 1/sqrt(5); the tier says so honestly)
- `@specifies` (tracer refusals become pytest skips, not failures) and `@specifies.property` for facts with no closed form (centered output sums to zero)
- 8 tests through the public API only

Deliberately not here yet: Piecewise seams, `assume=` normalization, atoms-relative verdicts, coverage proofs. The scaffold is the skeleton those land on.