### PR TITLE
specifies follow-up: restore the hardening net, board-forced checker fixes

### DIFF
--- a/coverage/spec_board.py
+++ b/coverage/spec_board.py
@@ -1,0 +1,205 @@
+"""Spec board: docstring formulas held to their implementations.
+
+Every spec below is transcribed from the function's OWN docstring (or
+the textbook identity the docstring names) -- never from the trace.
+The board measures the @specifies story end to end: how much shipped
+numerical Python can be held to the mathematics it documents, and at
+which verdict tier.
+
+LOCAL ONLY until findings are adjudicated: a `differs` here is either
+a transcription slip on our side or a real doc-vs-code divergence,
+and only a human read decides which.
+"""
+
+import sys
+import warnings
+from collections import Counter
+
+warnings.filterwarnings("ignore")
+sys.setrecursionlimit(20000)
+
+import numpy as np
+import sympy
+
+from skverify.testing import check_formula
+
+i = sympy.Symbol("i", integer=True)
+
+
+def J():
+    return sympy.Dummy("j", integer=True)
+
+
+N = 5
+V = sympy.IndexedBase("v")
+W = sympy.IndexedBase("w")
+U = sympy.IndexedBase("u")
+POS = np.array([0.7, 1.2, 2.5, 0.3, 0.4])
+MIX = np.array([0.7, -1.2, 2.5, 0.3, -0.4])
+U3 = np.array([1.0, 2.0, 3.0])
+W3 = np.array([2.0, 1.0, 5.0])
+PROB = np.array([0.1, 0.2, 0.4, 0.2, 0.1])
+
+j = J()
+MEAN = sympy.Sum(V[j], (j, 0, N - 1)) / N
+j = J()
+VAR = sympy.Sum((V[j] - MEAN) ** 2, (j, 0, N - 1)) / N
+STD = sympy.sqrt(VAR)
+
+
+def S(expr_fn):
+    """Sum over a fresh dummy: S(lambda j: V[j]**2)."""
+    jj = J()
+    return sympy.Sum(expr_fn(jj), (jj, 0, N - 1))
+
+
+def S3(expr_fn):
+    jj = J()
+    return sympy.Sum(expr_fn(jj), (jj, 0, 2))
+
+
+BOARD = []
+
+
+def entry(name, fn, args, spec, indices=(), assume=(), note=""):
+    BOARD.append((name, fn, args, spec, indices, assume, note))
+
+
+# numpy: docstring formulas ------------------------------------------
+entry("numpy.average(w)", lambda v, w: np.average(v, weights=w),
+      (POS, POS[::-1].copy()),
+      S(lambda k: V[k] * W[k]) / S(lambda k: W[k]))
+entry("numpy.var", lambda v: np.var(v), (MIX,), VAR)
+entry("numpy.std", lambda v: np.std(v), (MIX,), STD)
+entry("numpy.diff", lambda v: np.diff(v), (MIX,), V[i + 1] - V[i], (i,))
+entry("numpy.trapezoid", lambda v: np.trapezoid(v), (MIX,),
+      V[0] / 2 + V[1] + V[2] + V[3] + V[4] / 2)
+
+# scipy.stats ---------------------------------------------------------
+import scipy.stats as st
+
+entry("stats.zscore", lambda v: st.zscore(v), (MIX,),
+      (V[i] - MEAN) / STD, (i,))
+entry("stats.gmean", lambda v: st.gmean(v), (POS,),
+      sympy.exp(S(lambda k: sympy.log(V[k])) / N))
+entry("stats.hmean", lambda v: st.hmean(v), (POS,),
+      N / S(lambda k: 1 / V[k]),
+      assume=[V[k] > 0 for k in range(N)])
+entry("stats.pmean(p=3)", lambda v: st.pmean(v, 3), (POS,),
+      (S(lambda k: V[k] ** 3) / N) ** sympy.Rational(1, 3),
+      assume=[V[k] > 0 for k in range(N)])
+entry("stats.sem", lambda v: st.sem(v), (MIX,),
+      sympy.sqrt(S(lambda k: (V[k] - MEAN) ** 2) / (N - 1)) / sympy.sqrt(N))
+entry("stats.variation", lambda v: st.variation(v), (POS,), STD / MEAN)
+entry("stats.moment(2)", lambda v: st.moment(v, 2), (MIX,),
+      S(lambda k: (V[k] - MEAN) ** 2) / N)
+entry("stats.skew", lambda v: st.skew(v), (MIX,),
+      (S(lambda k: (V[k] - MEAN) ** 3) / N) / VAR ** sympy.Rational(3, 2))
+entry("stats.kurtosis", lambda v: st.kurtosis(v), (MIX,),
+      (S(lambda k: (V[k] - MEAN) ** 4) / N) / VAR ** 2 - 3)
+_tot = S(lambda k: V[k])
+entry("stats.entropy", lambda v: st.entropy(v), (PROB,),
+      -S(lambda k: (V[k] / _tot) * sympy.log(V[k] / _tot)),
+      assume=[V[k] > 0 for k in range(N)],
+      note="docstring: -sum(pk*log(pk)), pk normalized; positive domain")
+
+# scipy.special -------------------------------------------------------
+import scipy.special as sp
+
+entry("special.softmax", lambda v: sp.softmax(v), (MIX,),
+      sympy.exp(V[i] - V[2]) / S(lambda k: sympy.exp(V[k] - V[2])), (i,))
+entry("special.logsumexp", lambda v: sp.logsumexp(v), (MIX,),
+      sympy.log(S(lambda k: sympy.exp(V[k]))))
+entry("special.log_softmax", lambda v: sp.log_softmax(v), (MIX,),
+      V[i] - V[2] - sympy.log(S(lambda k: sympy.exp(V[k] - V[2]))), (i,))
+entry("special.expit", lambda v: sp.expit(v), (MIX,),
+      1 / (1 + sympy.exp(-V[i])), (i,))
+
+# scipy.spatial.distance: docstrings all carry formulas ---------------
+import scipy.spatial.distance as sd
+
+entry("distance.euclidean", lambda u, w: sd.euclidean(u, w), (U3, W3),
+      sympy.sqrt(S3(lambda k: (U[k] - W[k]) ** 2)))
+entry("distance.sqeuclidean", lambda u, w: sd.sqeuclidean(u, w), (U3, W3),
+      S3(lambda k: (U[k] - W[k]) ** 2))
+entry("distance.cityblock", lambda u, w: sd.cityblock(u, w), (U3, W3),
+      S3(lambda k: sympy.Abs(U[k] - W[k])))
+entry("distance.chebyshev", lambda u, w: sd.chebyshev(u, w), (U3, W3),
+      sympy.Max(*[sympy.Abs(U[k] - W[k]) for k in range(3)]))
+entry("distance.minkowski(p=3)", lambda u, w: sd.minkowski(u, w, 3), (U3, W3),
+      S3(lambda k: sympy.Abs(U[k] - W[k]) ** 3) ** sympy.Rational(1, 3))
+entry("distance.cosine", lambda u, w: sd.cosine(u, w), (U3, W3),
+      1 - S3(lambda k: U[k] * W[k])
+      / (sympy.sqrt(S3(lambda k: U[k] ** 2)) * sympy.sqrt(S3(lambda k: W[k] ** 2))))
+entry("distance.braycurtis", lambda u, w: sd.braycurtis(u, w), (U3, W3),
+      S3(lambda k: sympy.Abs(U[k] - W[k])) / S3(lambda k: sympy.Abs(U[k] + W[k])))
+entry("distance.canberra", lambda u, w: sd.canberra(u, w), (U3, W3),
+      S3(lambda k: sympy.Abs(U[k] - W[k]) / (sympy.Abs(U[k]) + sympy.Abs(W[k]))))
+
+# scipy.integrate / signal -------------------------------------------
+import scipy.integrate as si
+import scipy.signal as sg
+
+entry("integrate.trapezoid", lambda v: si.trapezoid(v), (MIX,),
+      V[0] / 2 + V[1] + V[2] + V[3] + V[4] / 2)
+entry("integrate.simpson", lambda v: si.simpson(v), (MIX,),
+      (V[0] + 4 * V[1] + 2 * V[2] + 4 * V[3] + V[4]) / 3)
+entry("signal.detrend(const)", lambda v: sg.detrend(v, type="constant"),
+      (MIX,), V[i] - MEAN, (i,))
+
+# sklearn.metrics: docstring formulas --------------------------------
+try:
+    import sklearn.metrics as sm
+
+    Y, P = sympy.IndexedBase("y_true"), sympy.IndexedBase("y_pred")
+    yt = np.array([1.0, 2.0, 3.0, 4.0])
+    yp = np.array([1.1, 1.9, 3.2, 3.7])
+
+    def S4(expr_fn):
+        jj = J()
+        return sympy.Sum(expr_fn(jj), (jj, 0, 3))
+
+    entry("metrics.mean_squared_error",
+          lambda y_true, y_pred: sm.mean_squared_error(y_true, y_pred),
+          (yt, yp), S4(lambda k: (Y[k] - P[k]) ** 2) / 4)
+    entry("metrics.mean_absolute_error",
+          lambda y_true, y_pred: sm.mean_absolute_error(y_true, y_pred),
+          (yt, yp), S4(lambda k: sympy.Abs(Y[k] - P[k])) / 4)
+    ym = S4(lambda k: Y[k]) / 4
+    entry("metrics.r2_score",
+          lambda y_true, y_pred: sm.r2_score(y_true, y_pred),
+          (yt, yp),
+          1 - S4(lambda k: (Y[k] - P[k]) ** 2) / S4(lambda k: (Y[k] - ym) ** 2))
+except ImportError:
+    pass
+
+
+def main():
+    tally = Counter()
+    findings = []
+    for name, fn, args, spec, indices, assume, note in BOARD:
+        try:
+            v = check_formula(fn, tuple(a.copy() for a in args), spec,
+                              indices=indices, assume=assume)
+            tier = v.tier
+        except Exception as e:
+            tier = f"BOARD-ERROR {type(e).__name__}"
+            v = None
+        tally[tier.split()[0]] += 1
+        flag = "" if v and v.matches else "  <--"
+        print(f"  {name:34s} {tier:16s}{flag}")
+        if v is not None and not v.matches:
+            findings.append((name, v, note))
+    total = len(BOARD)
+    print(f"\n== {total} docstring specs ==")
+    for k, n in tally.most_common():
+        print(f"  {k:16s} {n:3d}  ({100 * n / total:.0f}%)")
+    if findings:
+        print("\n== for adjudication (transcription slip vs real divergence) ==")
+        for name, v, note in findings:
+            print(f"\n-- {name}" + (f"   [{note}]" if note else ""))
+            print("   " + v.message().replace("\n", "\n   ")[:500])
+
+
+if __name__ == "__main__":
+    main()

--- a/skverify/api.py
+++ b/skverify/api.py
@@ -292,6 +292,7 @@ def to_sympy(fn, *args, **kwargs):
             )
         out.unchecked = tuple(records)
         out.instrumented = sites
+        _refuse_lost_influence(out, wrapped, fn, args, kwargs)
     except (AttributeError, TypeError) as harvest_err:
         # slots-only/immutable results legitimately reject attribute
         # writes; anything else here is a swallowed harvest bug
@@ -600,3 +601,45 @@ def _infer_names(fn, args):
     if len(args) > len(names):
         raise TypeError(f"{fn.__name__} takes {len(names)} arguments, got {len(args)}")
     return zip(names, args)
+
+
+def _refuse_lost_influence(out, wrapped, fn, args, kwargs):
+    """A constant formula from symbolic inputs is either honest
+    (the function really ignores the data) or the worst bug class
+    (a library layer stripped the traced array and the trace watched
+    plain numpy). The value lane arbitrates: rerun the REAL function
+    on slightly perturbed inputs; if the output moves while the
+    formula cannot, refuse loudly instead of certifying a constant."""
+    if not isinstance(out, Pair):
+        return
+    f = out.formula
+    if not isinstance(f, sympy.Basic) or f.free_symbols:
+        return
+    if not any(
+        isinstance(w, Pair)
+        and isinstance(w.formula, sympy.Basic)
+        and w.formula.free_symbols
+        for w in wrapped
+    ):
+        return
+    try:
+        perturbed = tuple(
+            a * 1.0009
+            if isinstance(a, np.ndarray) and np.issubdtype(a.dtype, np.floating)
+            else a
+            for a in args
+        )
+        ref = np.asarray(fn(*perturbed, **kwargs), dtype=float)
+        if not np.all(np.isfinite(ref)):
+            return  # perturbation left the domain: inconclusive
+        if not np.allclose(ref, float(f), rtol=1e-4, atol=1e-8):
+            raise NotImplementedError(
+                "the output depends on the input data but the traced "
+                "formula is a constant: a library layer converted the "
+                "traced array to plain numpy mid-call. Refusing rather "
+                "than certify a constant -- please report this."
+            )
+    except NotImplementedError:
+        raise
+    except Exception:
+        return  # rerun failed for its own reasons: inconclusive

--- a/skverify/testing.py
+++ b/skverify/testing.py
@@ -26,7 +26,7 @@ class Verdict:
     """The outcome of one spec check. Never a bare boolean: the tier
     and the shape it was decided at are part of the result."""
 
-    tier: str  # "exact" | "float-constant" | "differs" | "incomplete"
+    tier: str  # exact | float-constant | sampled | differs | undecided | incomplete
     shape: tuple
     spec: object = None
     traced: object = None
@@ -35,7 +35,7 @@ class Verdict:
 
     @property
     def matches(self):
-        return self.tier in ("exact", "float-constant")
+        return self.tier in ("exact", "float-constant", "sampled")
 
     def message(self):
         head = f"verdict: {self.tier} (at shape {self.shape})"
@@ -135,26 +135,34 @@ def check_formula(fn, args, spec, indices=(), assume=(), samples=3):
         else:
             t = out.formula.subs(at) if at else out.formula
         s = spec_b.subs(at) if at else spec_b
-        verdict, used_sampling = _entry_equal(t, s, entry, samples, assume)
+        verdict, used_sampling = _entry_equal(
+            t, s, entry, samples, assume, getattr(out, "preconditions", ())
+        )
         sampled = sampled or used_sampling
         if verdict is not None:
             verdict.shape = shape
             return verdict
     # the tier states HOW the decision was made: exact means every
-    # entry's difference vanished symbolically; float-constant means
-    # at least one entry needed arbitration at exact sample points
-    # (the code computes with rounded irrationals, so symbolic zero
-    # is impossible there)
-    tier = "float-constant" if sampled else "exact"
-    detail = (
-        f"{len(entries)}/{len(entries)} entries agree"
-        + (
-            "; code computes with rounded float constants, agreement "
-            f"verified at {samples} exact rational points"
-            if sampled
-            else ""
-        )
-    )
+    # entry's difference vanished symbolically. When at least one
+    # entry needed arbitration at exact sample points, the tier says
+    # WHY symbolic zero was out of reach: float-constant when the
+    # trace carries rounded constants (a zscore's 1/sqrt(5) can never
+    # equal an exact spec), sampled when the reason is structural
+    # (path guards, or a difference simplify cannot close in budget)
+    if not sampled:
+        tier = "exact"
+        why = ""
+    elif isinstance(out.formula, sympy.Basic) and any(
+        isinstance(a, sympy.Float) for a in out.formula.atoms(sympy.Number)
+    ):
+        tier = "float-constant"
+        why = ("; code computes with rounded float constants, agreement "
+               f"verified at {samples} exact rational points")
+    else:
+        tier = "sampled"
+        why = (f"; agreement verified at {samples} exact rational points "
+               "within the traced path's guards")
+    detail = f"{len(entries)}/{len(entries)} entries agree" + why
     return Verdict(tier=tier, shape=shape, spec=spec, detail=detail)
 
 
@@ -212,17 +220,59 @@ def _draw_point(slots, syms, rng, assume, tries=64):
     return None
 
 
-def _entry_equal(t, s, entry, samples, assume=()):
+def _zero_within_budget(d, seconds=10):
+    """Is ``d`` symbolically zero, giving simplify a bounded slice of
+    time? Cheap closers run first (expand, together/cancel); the full
+    simplify runs under a POSIX alarm where available -- a CI tool may
+    never hang on one stubborn difference. On timeout or off-POSIX the
+    answer is False and arbitration decides at sample points."""
+    try:
+        e = sympy.expand(d.doit())
+        if e == 0:
+            return True
+        e2 = sympy.cancel(sympy.together(e))
+        if e2 == 0:
+            return True
+    except Exception:
+        return False
+    import signal
+    import threading
+
+    if (
+        hasattr(signal, "SIGALRM")
+        and threading.current_thread() is threading.main_thread()
+    ):
+        def _timeout(signum, frame):
+            raise TimeoutError
+
+        old = signal.signal(signal.SIGALRM, _timeout)
+        signal.setitimer(signal.ITIMER_REAL, seconds)
+        try:
+            return sympy.simplify(e2) == 0
+        except (TimeoutError, Exception):
+            return False
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, old)
+    from .helpers import ops_capped
+
+    if ops_capped(e2, 2000) is not None:  # small enough to risk
+        try:
+            return sympy.simplify(e2) == 0
+        except Exception:
+            return False
+    return False
+
+
+def _entry_equal(t, s, entry, samples, assume=(), guards=()):
     """(verdict, used_sampling): verdict is None when the entry
     agrees. Exact tier first, sample-point arbitration second; sample
-    points are drawn to satisfy ``assume`` (a spec is only claimed on
-    its stated domain)."""
-    try:
-        d = sympy.simplify(sympy.expand((t - s).doit()))
-        if d == 0:
-            return None, False
-    except Exception:
-        pass
+    points are drawn to satisfy ``assume`` AND the traced path's own
+    guards -- a per-path formula is only claimed on its path (a
+    chebyshev trace that picked element 2 as the max must not be
+    sampled where element 0 wins)."""
+    if _zero_within_budget(t - s):
+        return None, False
     rng = np.random.default_rng(0)
     # unroll reductions FIRST: a spec's Sum binds a dummy, and only
     # after doit() do its terms carry concrete indices a sample point
@@ -243,7 +293,12 @@ def _entry_equal(t, s, entry, samples, assume=()):
     agree = True
     point = {}
     for _ in range(samples):
-        subs = _draw_point(slots, syms, rng, assume)
+        conds = list(assume)
+        if isinstance(guards, sympy.Basic) and guards not in (sympy.true,):
+            conds.extend(
+                guards.args if isinstance(guards, sympy.And) else [guards]
+            )
+        subs = _draw_point(slots, syms, rng, conds)
         if subs is None:
             return Verdict(
                 tier="undecided",

--- a/tests/checks/test_lost_influence.py
+++ b/tests/checks/test_lost_influence.py
@@ -1,0 +1,44 @@
+"""A constant formula from data-dependent code must refuse, never
+certify. Legitimate constants (code that really ignores the data)
+must keep lifting."""
+
+import numpy as np
+import pytest
+
+from skverify import to_sympy
+
+
+class TestLostInfluenceRefusal:
+    def test_scipy_sem_refuses_loudly(self):
+        # stats.sem strips the traced array in scipy's array-api layer;
+        # the trace watches plain numpy and produces a constant
+        stats = pytest.importorskip("scipy.stats")
+
+        def f(v):
+            return stats.sem(v)
+
+        with pytest.raises(NotImplementedError, match="constant"):
+            to_sympy(f, np.array([0.7, -1.2, 2.5, 0.3, -0.4]))
+
+
+class TestLegitimateConstantsStillLift:
+    def test_data_cancels_exactly(self):
+        def f(v):
+            return (v - v).sum()  # always 0, honestly
+
+        out = to_sympy(f, np.array([1.0, 2.0, 3.0]))
+        assert float(out.value) == 0.0
+
+    def test_shape_only(self):
+        def f(v):
+            return float(v.shape[0]) * 2.0
+
+        out = to_sympy(f, np.array([1.0, 2.0, 3.0]))
+        assert float(out.value) == 6.0
+
+    def test_zeros_like_sum(self):
+        def f(v):
+            return np.zeros_like(v).sum()
+
+        out = to_sympy(f, np.array([4.0, 5.0]))
+        assert float(out.value) == 0.0

--- a/tests/checks/test_spec_diff_burnin.py
+++ b/tests/checks/test_spec_diff_burnin.py
@@ -1,0 +1,159 @@
+"""Burn-in for the @specifies core loop: handwritten specs diffed
+symbolically against traced formulas. Every case here is exactly what
+check_formula will do; a spurious nonzero diff means the exit normal
+form or the trace drifted from human-written mathematics."""
+
+import numpy as np
+import pytest
+import sympy
+
+from skverify import to_sympy
+from skverify.helpers import axis_idx
+
+I = axis_idx(0)
+N = 5
+V = sympy.IndexedBase("v")
+VALS = np.array([0.7, -1.2, 2.5, 0.3, -0.4])
+
+
+def _mean():
+    j = sympy.Dummy("j", integer=True)
+    return sympy.Sum(V[j], (j, 0, N - 1)) / N
+
+
+def _entrywise_zero(traced, spec, n=N):
+    """The check_formula core: per-entry diff at concrete indices."""
+    for k in range(n):
+        t = traced.subs(I, k) if isinstance(traced, sympy.Basic) else traced
+        s = spec.subs(I, k)
+        d = sympy.simplify(sympy.expand(t - s).doit())
+        assert d == 0, f"entry {k}: {t} vs {s}"
+
+
+class TestScalarSpecs:
+    def test_mean(self):
+        out = to_sympy(lambda v: v.mean(), VALS.copy())
+        assert sympy.simplify(out.formula.doit() - _mean().doit()) == 0
+
+    def test_norm_squared(self):
+        def f(v):
+            return (v ** 2).sum()
+
+        out = to_sympy(f, VALS.copy())
+        j = sympy.Dummy("j", integer=True)
+        spec = sympy.Sum(V[j] ** 2, (j, 0, N - 1))
+        assert sympy.simplify(out.formula.doit() - spec.doit()) == 0
+
+    def test_variance_population(self):
+        out = to_sympy(lambda v: v.var(), VALS.copy())
+        j = sympy.Dummy("j", integer=True)
+        spec = sympy.Sum((V[j] - _mean()) ** 2, (j, 0, N - 1)) / N
+        d = sympy.simplify(sympy.expand(out.formula.doit() - spec.doit()))
+        assert d == 0
+
+    def test_weighted_mean(self):
+        W = sympy.IndexedBase("w")
+        wvals = np.array([1.0, 2.0, 3.0, 4.0, 0.5])
+
+        def f(v, w):
+            return (v * w).sum() / w.sum()
+
+        out = to_sympy(f, VALS.copy(), wvals.copy())
+        j = sympy.Dummy("j", integer=True)
+        spec = sympy.Sum(V[j] * W[j], (j, 0, N - 1)) / sympy.Sum(
+            W[j], (j, 0, N - 1)
+        )
+        assert sympy.simplify(out.formula.doit() - spec.doit()) == 0
+
+    def test_horner_is_polynomial(self):
+        def f(v):
+            acc = 0.0
+            for k in range(v.shape[0]):
+                acc = acc * 2.0 + v[k]
+            return acc
+
+        out = to_sympy(f, VALS.copy())
+        spec = sum(V[k] * sympy.Integer(2) ** (N - 1 - k) for k in range(N))
+        assert sympy.simplify(sympy.expand(out.formula) - spec) == 0
+
+
+class TestEntrywiseSpecs:
+    def test_zscore_float_constant_tier(self):
+        # the burn-in finding that shaped the verdict ladder: numpy
+        # computes 1/sqrt(5) as a rounded float, so the traced formula
+        # is exact about the CODE but differs from exact mathematics
+        # at the 16th digit. The honest verdict is tier 2: the diff
+        # vanishes numerically at exact sample points, and check_formula
+        # must label it "matches (float-constant)", never "exact".
+        def f(v):
+            return (v - v.mean()) / v.std()
+
+        out = to_sympy(f, VALS.copy())
+        j = sympy.Dummy("j", integer=True)
+        mean = _mean()
+        std = sympy.sqrt(
+            sympy.Sum((V[j] - mean) ** 2, (j, 0, N - 1)) / N
+        )
+        spec = (V[I] - mean) / std
+        rng = np.random.default_rng(7)
+        for trial in range(3):
+            pt = {V[k]: sympy.Rational(int(x), 100)
+                  for k, x in enumerate(rng.integers(-300, 300, N))}
+            for k in range(N):
+                t = float(out.formula.subs(I, k).doit().xreplace(pt))
+                s = float(spec.subs(I, k).doit().xreplace(pt))
+                assert abs(t - s) < 1e-10 * max(1.0, abs(s)), (trial, k)
+
+    def test_softmax(self):
+        def f(v):
+            e = np.exp(v - v.max())
+            return e / e.sum()
+
+        out = to_sympy(f, VALS.copy())
+        # spec under the traced ordering: max is v[2] for this input
+        j = sympy.Dummy("j", integer=True)
+        denom = sympy.Sum(sympy.exp(V[j] - V[2]), (j, 0, N - 1))
+        spec = sympy.exp(V[I] - V[2]) / denom
+        _entrywise_zero(out.formula, spec)
+
+    def test_affine(self):
+        def f(v):
+            return 3.0 * v + 1.0
+
+        out = to_sympy(f, VALS.copy())
+        _entrywise_zero(out.formula, 3 * V[I] + 1)
+
+    def test_diff_spec(self):
+        out = to_sympy(lambda v: np.diff(v), VALS.copy())
+        _entrywise_zero(out.formula, V[I + 1] - V[I], n=N - 1)
+
+
+class TestPropertySpecs:
+    def test_softmax_normalizes(self):
+        # rung 2: a property, no closed form -- entries sum to one
+        def f(v):
+            e = np.exp(v - v.max())
+            return e / e.sum()
+
+        out = to_sympy(f, VALS.copy())
+        total = sum(out.formula.subs(I, k) for k in range(N))
+        assert sympy.simplify(total.doit()) == 1
+
+    def test_gram_symmetric(self):
+        def f(a):
+            return a.T @ a
+
+        A = np.arange(6.0).reshape(2, 3) + 1
+        out = to_sympy(f, A)
+        J = axis_idx(1)
+        d = out.formula - out.formula.subs({I: J, J: I}, simultaneous=True)
+        assert sympy.simplify(d.doit()) == 0
+
+    def test_centering_kills_the_mean(self):
+        # property: centered data has exactly zero mean
+        def f(v):
+            return v - v.mean()
+
+        out = to_sympy(f, VALS.copy())
+        total = sum(out.formula.subs(I, k) for k in range(N))
+        assert sympy.simplify(sympy.expand(total.doit())) == 0

--- a/tests/instrument/test_trace_determinism.py
+++ b/tests/instrument/test_trace_determinism.py
@@ -1,0 +1,129 @@
+"""A testing tool must give the same verdict every run.
+
+Three nets: trace-order independence across fresh processes (the twin
+caches are process-global, so order effects only show between
+processes), repeated-trace stability inside one process, and session
+isolation under the repeated to_sympy calls check_formula will make.
+"""
+
+import json
+import subprocess
+import sys
+import textwrap
+
+import numpy as np
+import pytest
+import sympy
+
+from skverify import to_sympy
+
+PY = sys.executable
+
+MENU = textwrap.dedent(
+    """
+    import warnings, sys, json
+    warnings.filterwarnings("ignore")
+    sys.setrecursionlimit(20000)
+    import numpy as np
+    from skverify import to_sympy
+
+    def f_std(v): return (v - v.mean()) / v.std()
+    def f_soft(v):
+        e = np.exp(v - v.max())
+        return e / e.sum()
+    def f_median(v): return np.median(v)
+    def f_gram(a): return a.T @ a
+    def f_horner(v):
+        acc = 0.0
+        for k in range(v.shape[0]):
+            acc = acc * 2.0 + v[k]
+        return acc
+
+    FNS = {"std": f_std, "soft": f_soft, "median": f_median,
+           "gram": f_gram, "horner": f_horner}
+    v = np.array([0.7, -1.2, 2.5, 0.3, -0.4])
+    A = np.arange(6.0).reshape(2, 3) + 1
+    ARGS = {"gram": (A,)}
+
+    order = sys.argv[1].split(",")
+    certs = {}
+    for name in order:
+        out = to_sympy(FNS[name], *ARGS.get(name, (v.copy(),)))
+        f = out.formula
+        try:
+            import sympy
+            body = (" ; ".join(str(e) for e in f)
+                    if isinstance(f, sympy.NDimArray) else str(f))
+        except Exception:
+            body = str(f)
+        certs[name] = body + " ## " + str(out.preconditions)
+    print(json.dumps(certs))
+    """
+)
+
+
+def _run(order):
+    r = subprocess.run(
+        [PY, "-c", MENU, order], capture_output=True, text=True, timeout=300
+    )
+    assert r.returncode == 0, r.stderr[-800:]
+    return json.loads(r.stdout.strip().splitlines()[-1])
+
+
+class TestTraceOrderIndependence:
+    def test_two_orders_identical(self):
+        a = _run("std,soft,median,gram,horner")
+        b = _run("horner,gram,median,soft,std")
+        assert a == b
+
+    def test_warm_cache_matches_cold(self):
+        # tracing gram twice: second (warm-twin) trace must equal first
+        a = _run("gram,gram")
+        assert a["gram"] == _run("gram")["gram"]
+
+
+class TestRepeatedTraceStability:
+    def test_same_function_thrice_interleaved(self):
+        def f(v):
+            return (v - v.mean()) / v.std()
+
+        def g(v):
+            return np.sort(v)[1] * 2.0
+
+        v = np.array([0.7, -1.2, 2.5, 0.3, -0.4])
+        first = str(to_sympy(f, v.copy()).formula)
+        to_sympy(g, v.copy())
+        second = str(to_sympy(f, v.copy()).formula)
+        to_sympy(g, v.copy())
+        third = str(to_sympy(f, v.copy()).formula)
+        assert first == second == third
+
+    def test_check_formula_style_loop(self):
+        # the @specifies pattern: many traces in a tight loop, sessions
+        # must not leak guards or definitions across calls
+        def f(v):
+            if v.sum() > 0:
+                return v * 2.0
+            return v
+
+        v = np.array([1.0, 2.0, 3.0])
+        results = [to_sympy(f, v.copy()) for _ in range(5)]
+        pres = {str(r.preconditions) for r in results}
+        forms = {str(r.formula) for r in results}
+        assert len(pres) == 1, pres
+        assert len(forms) == 1, forms
+
+    def test_guards_do_not_accumulate(self):
+        def guarded(v):
+            if v[0] > 0:
+                return v.sum()
+            return 0.0
+
+        v = np.array([1.0, 2.0])
+        n_guards = []
+        for _ in range(3):
+            out = to_sympy(guarded, v.copy())
+            pre = out.preconditions
+            n = len(pre.args) if isinstance(pre, sympy.And) else 1
+            n_guards.append(n)
+        assert n_guards[0] == n_guards[1] == n_guards[2], n_guards

--- a/tests/testing/test_specifies_scipy.py
+++ b/tests/testing/test_specifies_scipy.py
@@ -86,8 +86,13 @@ class TestStats:
         spec = N / sympy.Sum(1 / V[j], (j, 0, N - 1))
         v = check_formula(lambda v: st.hmean(v), (VALS.copy(),), spec)
         if branched:
-            # nan branches exist: the unqualified spec must NOT match
-            assert not v.matches
+            # per-path semantics: arbitration samples WITHIN the traced
+            # path's guards, so the spec matches on the positive path it
+            # was traced on -- and the restriction is DISCLOSED: the
+            # verdict cannot be an unqualified match
+            assert v.matches
+            assert v.tier in ("sampled", "float-constant")
+            assert out.preconditions is not sympy.true
         else:
             # branch-free implementation IS the spec, everywhere
             assert v.tier == "exact"


### PR DESCRIPTION
Two commits that landed on the branch after #38 was merged.

**Restore the hardening net (`9934e22`).** The squash-merge of #33 predates this commit, so master never got it: the lost-influence refusal (a constant formula from symbolic inputs reruns the real function perturbed and refuses if the output moves -- catches `scipy.stats.sem` silently certifying a constant), the trace-determinism tests, and the spec-diff burn-in file.

**Checker fixes the spec board forced (`eeac589`).**

- Arbitration points now satisfy the traced path's own guards, not just `assume=`. A chebyshev trace that picked element 2 as the max must not be sampled where element 0 wins:

```python
out = to_sympy(lambda u, w: sd.chebyshev(u, w), u3, w3)
out.formula        # Abs(u[2] - w[2])
out.preconditions  # Abs(u[2]-w[2]) > Abs(u[0]-w[0]) & ...
# before: sampled off-path -> spurious differs. now: sampled, matches
```

- Symbolic equality runs under a budget (cheap closers, then simplify under a 10s alarm). Found by an entropy spec that hung simplify indefinitely; a CI tool may never hang.
- New `sampled` tier: `float-constant` now fires only when the trace actually carries rounded floats; structural sampling (path guards) gets its own honest label.

Also adds `coverage/spec_board.py`: 33 docstring formulas from numpy/scipy/sklearn held to their implementations -- 31 match (16 exact, 9 float-constant, 6 sampled), 1 incomplete (sem, the new refusal), 1 undecided (the `Function('sqrt')` tracer bug in `distance.cosine`).

687 tests green on both counts.