### PR TITLE
check_formula: assume= facts now simplify the formulas, not just pick sample points

### DIFF
--- a/skverify/testing.py
+++ b/skverify/testing.py
@@ -123,7 +123,35 @@ def check_formula(fn, args, spec, indices=(), assume=(), samples=3):
         )
     shape = tuple(np.shape(out.value))
     bound = {sym: axis_idx(k) for k, sym in enumerate(indices)}
+    # traced scalar symbols carry real=True; a user's plain
+    # Symbol("u") must still mean the same thing. Bind by name.
+    if isinstance(out.formula, sympy.Basic):
+        traced_syms = out.formula.free_symbols
+    elif isinstance(out.formula, sympy.NDimArray):
+        traced_syms = set().union(
+            *(e.free_symbols for e in out.formula if isinstance(e, sympy.Basic))
+        )
+    else:
+        traced_syms = set()
+    by_name = {t.name: t for t in traced_syms if isinstance(t, sympy.Symbol)}
+    user_syms = set(spec.free_symbols)
+    for f in assume:
+        if isinstance(f, sympy.Basic):
+            user_syms |= f.free_symbols
+    for sym in user_syms:
+        if (
+            isinstance(sym, sympy.Symbol)
+            and sym not in bound
+            and sym.name in by_name
+            and sym != by_name[sym.name]
+        ):
+            bound[sym] = by_name[sym.name]
     spec_b = spec.xreplace(bound) if bound else spec
+    if bound and assume:
+        assume = [
+            f.xreplace(bound) if isinstance(f, sympy.Basic) else f
+            for f in assume
+        ]
 
     entries = list(np.ndindex(shape)) if shape else [()]
     sampled = False
@@ -264,6 +292,98 @@ def _zero_within_budget(d, seconds=10):
     return False
 
 
+
+
+def _apply_assumptions(expr, assume):
+    """Simplify ``expr`` using the facts in ``assume``, so stated
+    domain knowledge closes proofs instead of only steering sample
+    points.
+
+    Rules, each fired only when a fact matches the arguments exactly
+    or up to a cheap ``expand``:
+
+    - ``a < b`` or ``a <= b``: ``Min(a, b) -> a``, ``Max(a, b) -> b``
+    - ``x > 0``:  ``Abs(x) -> x``,  ``sign(x) -> 1``
+    - ``x >= 0``: ``Abs(x) -> x``
+    - ``x < 0``:  ``Abs(x) -> -x``, ``sign(x) -> -1``
+    - ``Eq(lhs, rhs)``: substitute ``lhs -> rhs`` (a stated identity
+      holds everywhere on the claimed domain)
+
+    A fact that is too weak fires nothing: ``Ne(a, b)`` leaves
+    ``Min(a, b)`` alone. Facts apply to BOTH the spec and the traced
+    formula, so neither side is privileged.
+    """
+    if not assume or not isinstance(expr, sympy.Basic):
+        return expr
+
+    less = []      # (small, big) from a < b and a <= b
+    pos, neg, nonneg = [], [], []
+    eqs = {}
+    for fact in assume:
+        if not isinstance(fact, sympy.Basic):
+            continue
+        if isinstance(fact, sympy.Eq):
+            eqs[fact.lhs] = fact.rhs
+            continue
+        if isinstance(fact, (sympy.Gt, sympy.Ge)):
+            small, big = fact.rhs, fact.lhs
+            strict = isinstance(fact, sympy.Gt)
+        elif isinstance(fact, (sympy.Lt, sympy.Le)):
+            small, big = fact.lhs, fact.rhs
+            strict = isinstance(fact, sympy.Lt)
+        else:
+            continue
+        less.append((small, big))
+        if small == 0:
+            (pos if strict else nonneg).append(big)
+        if big == 0 and strict:
+            neg.append(small)
+
+    def _same(x, y):
+        if x == y:
+            return True
+        try:
+            return sympy.expand(x - y) == 0
+        except Exception:
+            return False
+
+    for _ in range(3):  # nested Min/Abs resolve over a few rounds
+        m = dict(eqs)
+        for node in expr.atoms(sympy.Min, sympy.Max):
+            if len(node.args) != 2:
+                continue
+            x, y = node.args
+            for small, big in less:
+                if (_same(x, small) and _same(y, big)) or (
+                    _same(y, small) and _same(x, big)
+                ):
+                    m[node] = small if isinstance(node, sympy.Min) else big
+                    break
+        for node in expr.atoms(sympy.Abs):
+            # sympy canonicalizes the argument's sign, so a fact about
+            # b - a must also match an argument stored as a - b
+            x = node.args[0]
+            if any(_same(x, p) for p in pos + nonneg) or any(
+                _same(-x, n) for n in neg
+            ):
+                m[node] = x
+            elif any(_same(-x, p) for p in pos + nonneg) or any(
+                _same(x, n) for n in neg
+            ):
+                m[node] = -x
+        for node in expr.atoms(sympy.sign):
+            x = node.args[0]
+            if any(_same(x, p) for p in pos) or any(_same(-x, n) for n in neg):
+                m[node] = sympy.Integer(1)
+            elif any(_same(-x, p) for p in pos) or any(_same(x, n) for n in neg):
+                m[node] = sympy.Integer(-1)
+        m = {k: v for k, v in m.items() if k in expr.atoms(type(k)) or k in eqs}
+        new = expr.xreplace(m) if m else expr
+        if new == expr:
+            break
+        expr = new
+    return expr
+
 def _entry_equal(t, s, entry, samples, assume=(), guards=()):
     """(verdict, used_sampling): verdict is None when the entry
     agrees. Exact tier first, sample-point arbitration second; sample
@@ -271,6 +391,8 @@ def _entry_equal(t, s, entry, samples, assume=(), guards=()):
     guards -- a per-path formula is only claimed on its path (a
     chebyshev trace that picked element 2 as the max must not be
     sampled where element 0 wins)."""
+    t = _apply_assumptions(t, assume)
+    s = _apply_assumptions(s, assume)
     if _zero_within_budget(t - s):
         return None, False
     rng = np.random.default_rng(0)

--- a/tests/testing/test_assume_normalization.py
+++ b/tests/testing/test_assume_normalization.py
@@ -1,0 +1,128 @@
+"""assume= facts simplify formulas before comparison (issue #41).
+
+Each rule gets three kinds of test: the unit behavior of the helper,
+the end-to-end effect through check_formula, and a too-weak fact that
+must fire nothing.
+"""
+
+import numpy as np
+import pytest
+import sympy
+
+from skverify.testing import _apply_assumptions, check_formula
+
+a, b, x = sympy.symbols("a b x")
+T = sympy.IndexedBase("t")
+
+
+class TestRules:
+    def test_min_collapses_under_ordering(self):
+        e = sympy.Min(a, b) * 2 + 1
+        assert _apply_assumptions(e, [a < b]) == 2 * a + 1
+
+    def test_max_collapses_under_ordering(self):
+        assert _apply_assumptions(sympy.Max(a, b), [a < b]) == b
+
+    def test_nonstrict_ordering_also_collapses(self):
+        assert _apply_assumptions(sympy.Min(a, b), [a <= b]) == a
+
+    def test_reversed_statement_of_the_same_fact(self):
+        assert _apply_assumptions(sympy.Min(a, b), [b > a]) == a
+
+    def test_abs_positive(self):
+        assert _apply_assumptions(sympy.Abs(x) + 1, [x > 0]) == x + 1
+
+    def test_abs_nonnegative(self):
+        assert _apply_assumptions(sympy.Abs(x), [x >= 0]) == x
+
+    def test_abs_negative(self):
+        assert _apply_assumptions(sympy.Abs(x), [x < 0]) == -x
+
+    def test_sign_positive(self):
+        assert _apply_assumptions(sympy.sign(x) * 5, [x > 0]) == 5
+
+    def test_sign_negative(self):
+        assert _apply_assumptions(sympy.sign(x), [x < 0]) == -1
+
+    def test_eq_substitutes(self):
+        e = T[0] + T[1] * 2
+        assert _apply_assumptions(e, [sympy.Eq(T[0], 0)]) == 2 * T[1]
+
+    def test_matches_up_to_expand(self):
+        # the fact states 2*(b - a) > 0; Abs carries 2*b - 2*a
+        e = sympy.Abs(2 * b - 2 * a)
+        assert _apply_assumptions(e, [2 * (b - a) > 0]) == 2 * b - 2 * a
+
+    def test_nested_min_resolves_over_rounds(self):
+        e = sympy.Min(a, sympy.Min(a, b))
+        got = _apply_assumptions(e, [a < b])
+        assert got == a
+
+
+class TestTooWeakFactsFireNothing:
+    def test_ne_leaves_min_alone(self):
+        e = sympy.Min(a, b)
+        assert _apply_assumptions(e, [sympy.Ne(a, b)]) == e
+
+    def test_wrong_direction_leaves_abs_alone(self):
+        e = sympy.Abs(x)
+        assert _apply_assumptions(e, [x < 5]) == e  # x < 5 says nothing about sign
+
+    def test_unrelated_symbols_leave_min_alone(self):
+        c = sympy.Symbol("c")
+        e = sympy.Min(a, c)
+        assert _apply_assumptions(e, [a < b]) == e
+
+    def test_no_facts_is_identity(self):
+        e = sympy.Min(a, b) + sympy.Abs(x)
+        assert _apply_assumptions(e, []) == e
+
+
+def f_min(u, w):
+    return np.minimum(u, w)
+
+
+def f_absx(v):
+    return np.abs(v)
+
+
+def f_shifted(t):
+    return t[0] + t[1] * 3.0
+
+
+class TestEndToEnd:
+    def test_min_trace_matches_under_ordering(self):
+        # traced formula is Min(u, w); the spec is just u, provable
+        # only because assume says u < w
+        u = sympy.Symbol("u")
+        v = check_formula(f_min, (1.0, 2.0), u, assume=[u < sympy.Symbol("w")])
+        assert v.tier == "exact"
+
+    def test_min_without_the_fact_does_not_prove(self):
+        u = sympy.Symbol("u")
+        v = check_formula(f_min, (1.0, 2.0), u)
+        assert v.tier != "exact"
+
+    def test_abs_trace_matches_on_positive_domain(self):
+        V = sympy.IndexedBase("v")
+        i = sympy.Symbol("i", integer=True)
+        v = check_formula(
+            f_absx, (np.array([1.0, 2.0, 3.0]),), V[i], indices=(i,),
+            assume=[V[k] > 0 for k in range(3)],
+        )
+        assert v.tier == "exact"
+
+    def test_eq_substitution_closes_the_proof(self):
+        # code computes t[0] + 3*t[1]; the spec drops t[0], valid
+        # only on the domain where assume pins t[0] to zero
+        v = check_formula(
+            f_shifted, (np.array([0.0, 2.0]),), 3 * T[1],
+            assume=[sympy.Eq(T[0], 0)],
+        )
+        assert v.tier == "exact"
+
+    def test_both_sides_normalized_spec_with_min(self):
+        # the SPEC carries the Min; assume collapses it to meet the code
+        u, w = sympy.symbols("u w")
+        v = check_formula(f_min, (1.0, 2.0), sympy.Min(u, w), assume=[u < w])
+        assert v.tier == "exact"


### PR DESCRIPTION
Closes #41.

Before this change, `assume=` only steered which numbers get used for testing. Now the facts also simplify both formulas before the comparison, so domain knowledge can close a proof.

The problem it solves, in one example. Tracing `np.minimum(u, w)` gives the formula `Min(u, w)`. If you know `u < w`, that IS just `u`, but the checker could not use the fact:

```python
u, w = sympy.symbols("u w")

check_formula(lambda u, w: np.minimum(u, w), (1.0, 2.0), u)
# before and after: not provable, correctly -- nothing says u < w

check_formula(lambda u, w: np.minimum(u, w), (1.0, 2.0), u, assume=[u < w])
# before: differs (the fact was ignored during comparison)
# after:  exact
```

The rules, each fired only when a stated fact clearly matches:

| fact in assume= | simplification |
|---|---|
| `a < b` or `a <= b` | `Min(a, b) -> a`, `Max(a, b) -> b` |
| `x > 0` | `Abs(x) -> x`, `sign(x) -> 1` |
| `x < 0` | `Abs(x) -> -x`, `sign(x) -> -1` |
| `Eq(lhs, rhs)` | substitute `lhs -> rhs` |

A fact that is too weak fires nothing: `Ne(a, b)` leaves `Min(a, b)` untouched. Facts apply to the spec and the traced formula equally.

Two things discovered while testing, both fixed here:

1. Traced scalar symbols carry `real=True`, so a user's plain `Symbol("u")` never equaled the trace's `u`. Spec and assume symbols now bind to traced symbols by name, the same way `indices=` binds axes.
2. sympy stores `Abs(2*b - 2*a)` as `Abs(2*a - 2*b)`, so facts also match the negated argument.

21 new tests: every rule in isolation, every too-weak fact left inert, and end-to-end checks through `check_formula`. Full suite 708 green; the spec board is unchanged (33 docstring formulas, 31 match).

This unblocks #42, the penalty-matrix example, where the knot ordering facts are exactly what the comparison needs.