### PR TITLE
test: verify spline penalty formulas

### DIFF
--- a/examples/penalty_matrix_check.ipynb
+++ b/examples/penalty_matrix_check.ipynb
@@ -410,6 +410,34 @@
     "[The report](https://github.com/aadya940/scipy-bspline-testing/blob/main/B_Splines_with_arbitary_knots-gcv.pdf) took weeks. This takes a couple of minutes, and it runs\n",
     "again whenever the code changes."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "specifies-penalty-entry",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This same formula check now runs on every commit in tests/testing/test_penalty_matrix.py.\n",
+    "from skverify.testing import specifies\n",
+    "\n",
+    "penalty_assumptions = [\n",
+    "    sympy.Eq(t[0], 0), sympy.Eq(t[1], 0), sympy.Eq(t[2], 0), sympy.Eq(t[3], 0),\n",
+    "    sympy.Eq(t[6], t[5]), sympy.Eq(t[7], t[5]), sympy.Eq(t[8], t[5]),\n",
+    "    t[4] > 0, t[5] > t[4],\n",
+    "]\n",
+    "\n",
+    "notebook_knots = np.array([0., 0., 0., 0., 1., 3., 3., 3., 3.])\n",
+    "\n",
+    "def penalty_entry_12(t):\n",
+    "    return penalty(t)[1, 2]\n",
+    "\n",
+    "@specifies(-12 / (t[4]**2 * t[5]), assume=penalty_assumptions)\n",
+    "def notebook_penalty_entry_matches_the_paper():\n",
+    "    return penalty_entry_12, (notebook_knots.copy(),)\n",
+    "\n",
+    "notebook_penalty_entry_matches_the_paper()\n"
+   ]
   }
  ],
  "metadata": {

--- a/tests/testing/test_penalty_matrix.py
+++ b/tests/testing/test_penalty_matrix.py
@@ -1,0 +1,82 @@
+"""Published spline penalty formulas checked against the NumPy construction."""
+
+import numpy as np
+import pytest
+import sympy
+
+from skverify.testing import specifies
+
+T = sympy.IndexedBase("t")
+KNOTS = np.array([0.0, 0.0, 0.0, 0.0, 1.0, 3.0, 3.0, 3.0, 3.0])
+KNOT_ASSUMPTIONS = [
+    sympy.Eq(T[0], 0),
+    sympy.Eq(T[1], 0),
+    sympy.Eq(T[2], 0),
+    sympy.Eq(T[3], 0),
+    sympy.Eq(T[6], T[5]),
+    sympy.Eq(T[7], T[5]),
+    sympy.Eq(T[8], T[5]),
+    T[4] > 0,
+    T[5] > T[4],
+]
+
+
+def penalty(t):
+    """Construct the cubic B-spline penalty matrix C.T @ R @ C."""
+    m = len(t) - 4
+    d1 = np.zeros((m + 1, m))
+    for j in range(m + 1):
+        run = t[j + 3] - t[j]
+        if run != 0:
+            if j - 1 >= 0:
+                d1[j, j - 1] = -3 / run
+            if j < m:
+                d1[j, j] = 3 / run
+
+    d2 = np.zeros((m + 2, m + 1))
+    for j in range(m + 2):
+        run = t[j + 2] - t[j]
+        if run != 0:
+            if j - 1 >= 0:
+                d2[j, j - 1] = -2 / run
+            if j < m + 1:
+                d2[j, j] = 2 / run
+
+    c = d2 @ d1
+    r = np.zeros((m + 2, m + 2))
+    for p in range(m + 2):
+        r[p, p] = (t[p + 2] - t[p]) / 3
+        if p + 1 < m + 2:
+            r[p, p + 1] = r[p + 1, p] = (t[p + 2] - t[p + 1]) / 6
+    return c.T @ r @ c
+
+
+def penalty_entry_00(t):
+    return penalty(t)[0, 0]
+
+
+def penalty_entry_12(t):
+    return penalty(t)[1, 2]
+
+
+@specifies(12 / T[4] ** 3, assume=KNOT_ASSUMPTIONS)
+def test_penalty_entry_00_matches_the_paper():
+    return penalty_entry_00, (KNOTS.copy(),)
+
+
+@specifies(-12 / (T[4] ** 2 * T[5]), assume=KNOT_ASSUMPTIONS)
+def test_penalty_entry_12_matches_the_paper():
+    return penalty_entry_12, (KNOTS.copy(),)
+
+
+def test_penalty_entry_wrong_sign_reports_both_formulas():
+    @specifies(12 / (T[4] ** 2 * T[5]), assume=KNOT_ASSUMPTIONS)
+    def check_wrong_sign():
+        return penalty_entry_12, (KNOTS.copy(),)
+
+    with pytest.raises(AssertionError) as exc_info:
+        check_wrong_sign()
+
+    message = str(exc_info.value)
+    assert "your spec" in message
+    assert "the code" in message


### PR DESCRIPTION
Adds `@specifies` checks for two spline penalty-matrix entries plus a wrong-sign regression that verifies useful failure output. The notebook now shows the decorator form and links it to the commit-running test.

Fixes #42

Tests: 703 passed, 8 skipped; notebook example executes successfully.
