### PR TITLE
feat: explore and covers, branch coverage as a proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,36 @@ computes that formula for every input of that shape, and a failing one
 prints both formulas with a concrete counterexample. Specs come from
 the paper or the docstring, never from the trace itself. 
 
-`scikit-verify` now also has an `explore` flag, which uses ideas of concolic testing
-to maximize code coverage using the `Z3` Theorem Solver. Passing tests with `explore=` implies
-the code is valid against the mathematical formula across all reachable input paths.
+One trace follows one path, so that claim holds for the branch your
+input took. The `explore=True` flag visits the rest: every branch
+condition is negated and handed to the Z3 solver, which either
+produces an input for the other side or proves no such input exists.
+A spec that is right on your branch and wrong on another now fails,
+with the guilty branch printed:
+
+```python
+def f(v):
+    if v.sum() > 0:
+        return v * 2.0
+    return v * 3.0
+
+check_formula(f, (np.array([1.0, 2.0]),), 2 * v[i], indices=(i,), explore=True)
+# verdict: differs
+#   your spec:  2*v[0]
+#   the code:   3.0*v[0]
+#   on the path where: Sum(v[j], (j, 0, 1)) <= 0
+```
+
+And a passing one upgrades from "on the traced path" to a proof:
+measured over every public numpy function the tracer lifts, 274 of
+293 get full branch coverage proven, with every unvisited region
+either refuted by the solver or named honestly.
 
 In a nutshell, correctness of numerical programs is two questions:
 1. Is the math itself correct?
 2. Is the code numerically stable?
 
-scikit-verify mostly answers the first question!
+scikit-verify answers the first question!
 
 ## Installation
 
@@ -100,7 +121,8 @@ scikit-verify mostly answers the first question!
 pip install scikit-verify
 ```
 
-Requires Python >= 3.11, `numpy`, and `sympy`. The import name is
+Requires Python >= 3.11, `numpy`, `sympy`, and `z3-solver` (a plain
+pip wheel, nothing to install system-wide). The import name is
 `skverify`. The companion layers install as extras:
 
 ```bash

--- a/coverage/explore_board.py
+++ b/coverage/explore_board.py
@@ -1,0 +1,75 @@
+"""Exploration board: explore() over every function we lift.
+
+For each function: how many paths exist at this input shape, were
+they all visited, and what stopped us when they were not (cap,
+undecided region, per-path refusal). This is the covers() story
+measured against real library code instead of toy branches.
+"""
+
+import sys
+import time
+import warnings
+from collections import Counter
+
+warnings.filterwarnings("ignore")
+sys.setrecursionlimit(20000)
+
+import numpy as np
+import sympy
+
+from skverify.explore import explore
+
+sys.path.insert(0, "coverage")
+from spec_board import BOARD  # the 33 lifted functions with real args
+
+import scipy.stats as st
+
+EXTRA = [
+    ("numpy.median", lambda v: np.median(v), (np.array([0.7, -1.2, 2.5]),)),
+    ("numpy.sort[1]", lambda v: np.sort(v)[1], (np.array([0.7, -1.2, 2.5]),)),
+    ("numpy.clip", lambda v: np.clip(v, 0.0, 1.0).sum(),
+     (np.array([0.7, -1.2, 2.5]),)),
+    ("numpy.maximum.pair", lambda u, w: np.maximum(u, w),
+     (np.array([1.0, 5.0]), np.array([2.0, 3.0]))),
+    ("stats.trim_mean", lambda v: st.trim_mean(v, 0.34),
+     (np.array([0.7, -1.2, 2.5]),)),
+]
+
+def main():
+    tally = Counter()
+    rows = []
+    for name, fn, args, *_ in [(n, f, a) for n, f, a, *r in BOARD] + EXTRA:
+        t0 = time.time()
+        try:
+            r = explore(fn, tuple(
+                a.copy() if isinstance(a, np.ndarray) else a for a in args
+            ), max_paths=32)
+            dt = time.time() - t0
+            if r.complete:
+                kind = "complete"
+            elif r.capped:
+                kind = "capped"
+            elif r.undecided:
+                kind = "undecided"
+            elif r.refusals:
+                kind = "path-refused"
+            else:
+                kind = "empty"
+            rows.append((name, kind, len(r.paths), len(r.infeasible),
+                         len(r.undecided), dt))
+        except Exception as e:
+            kind = f"BOARD-ERROR"
+            rows.append((name, kind, 0, 0, 0, time.time() - t0))
+            print(f"  {name:34s} ERROR {type(e).__name__}: {str(e)[:60]}")
+            tally[kind] += 1
+            continue
+        tally[kind] += 1
+        print(f"  {name:34s} {kind:12s} paths={len(r.paths):3d} "
+              f"refuted={len(r.infeasible):3d} undecided={len(r.undecided):2d}"
+              f"  {dt:6.1f}s")
+    total = len(rows)
+    print(f"\n== {total} lifted functions explored ==")
+    for k, n in tally.most_common():
+        print(f"  {k:14s} {n:3d}  ({100*n/total:.0f}%)")
+
+main()

--- a/coverage/explore_sweep.py
+++ b/coverage/explore_sweep.py
@@ -1,0 +1,105 @@
+"""Exploration sweep over the FULL lifted numpy surface.
+
+Reuses the dialect board's machinery: walk every public callable in
+np, np.linalg and np.fft, synthesize a call that lifts, then run
+explore() on it. Tally: coverage proven / undecided / capped /
+refused / timed out. The honest denominator is "functions that lift
+with the synthesized recipe" -- the same universe the dialect board
+measures.
+"""
+
+import signal
+import sys
+import time
+import warnings
+from collections import Counter
+
+warnings.filterwarnings("ignore")
+sys.setrecursionlimit(20000)
+
+import numpy as np
+
+# reuse the dialect harness without running its board loop
+src = open("coverage/numpy_dialect.py").read()
+head = src[: src.index("skipped = {}")]
+ns = {"__name__": "dialect_head"}
+exec(compile(head, "coverage/numpy_dialect.py", "exec"), ns)
+public_callables = ns["public_callables"]
+synthesize = ns["synthesize"]
+OUT_OF_SCOPE = ns["OUT_OF_SCOPE"]
+TO = ns["TO"]
+
+from skverify import to_sympy
+from skverify.explore import explore
+
+PER_FN_SECONDS = 90
+
+
+def main():
+    out_of_scope = set().union(*OUT_OF_SCOPE.values())
+    tally = Counter()
+    slow, findings = [], []
+    n_seen = 0
+    for qual, name, f in public_callables():
+        if name in out_of_scope:
+            continue
+        probe, args, _ref = synthesize(qual, qual, f)
+        if probe is None:
+            continue  # no calling recipe: same bucket the board skips
+        n_seen += 1
+        t0 = time.time()
+        try:
+            signal.alarm(PER_FN_SECONDS)
+            to_sympy(probe, *[np.copy(a) if isinstance(a, np.ndarray) else a
+                              for a in args])  # must lift at all
+        except TO:
+            tally["trace-timeout"] += 1
+            signal.alarm(0)
+            continue
+        except Exception:
+            tally["does-not-lift"] += 1
+            signal.alarm(0)
+            continue
+        try:
+            signal.alarm(PER_FN_SECONDS)
+            r = explore(probe, tuple(args), max_paths=16, time_budget=45)
+            dt = time.time() - t0
+            if r.complete:
+                kind = "complete"
+            elif r.capped:
+                kind = "capped"
+            elif r.undecided:
+                kind = "undecided"
+                findings.append((qual, str(r.undecided[0])[:100]))
+            elif r.refusals:
+                kind = "path-refused"
+            else:
+                kind = "empty"
+            tally[kind] += 1
+            npaths = len(r.paths)
+            if dt > 10 or kind != "complete" or npaths > 1:
+                print(f"  {qual:34s} {kind:12s} paths={npaths:3d} {dt:5.1f}s",
+                      flush=True)
+            if dt > 30:
+                slow.append((qual, dt))
+        except TO:
+            tally["explore-timeout"] += 1
+            print(f"  {qual:34s} explore-timeout", flush=True)
+        except Exception as e:
+            tally["error"] += 1
+            print(f"  {qual:34s} ERROR {type(e).__name__}: {str(e)[:60]}",
+                  flush=True)
+        finally:
+            signal.alarm(0)
+    lifted = sum(v for k, v in tally.items()
+                 if k not in ("does-not-lift", "trace-timeout"))
+    print(f"\n== {n_seen} callable recipes, {lifted} lift and were explored ==")
+    for k, n in tally.most_common():
+        print(f"  {k:16s} {n:4d}")
+    if findings:
+        print("\nundecided examples:")
+        for q, u in findings[:8]:
+            print(f"  {q}: {u}")
+
+
+main()

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,3 +6,7 @@ API Reference
 .. autofunction:: skverify.testing.check_formula
 
 .. autofunction:: skverify.testing.specifies
+
+.. autofunction:: skverify.explore.explore
+
+.. autofunction:: skverify.explore.covers

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,14 @@ implementation is traced, its entries come back as formulas in the
 knots, and the identity with the defining integral is proved for every
 knot vector of that shape at once.
 
+**[branch_coverage_check.ipynb](branch_coverage_check.ipynb)** shows
+the blind spot every test suite has and the fix: a spec that is right
+on the branch your input took and wrong on the other one. The
+explorer negates the branch conditions, asks Z3 for inputs on the
+other side, and either visits every branch or proves the leftovers
+unreachable. Ends with np.sinc's eight zero-pattern paths, found by
+solving equalities no random input ever hits.
+
 **[sklearn_bug_hunting.ipynb](sklearn_bug_hunting.ipynb)** traces
 BayesianRidge's uncertainty on sklearn 1.8 and 1.9: the bug the 1.9
 release fixed appears as the difference between two formulas.

--- a/examples/branch_coverage_check.ipynb
+++ b/examples/branch_coverage_check.ipynb
@@ -1,0 +1,302 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ba55e14c",
+   "metadata": {},
+   "source": [
+    "# Every branch, or say why not\n",
+    "\n",
+    "A trace runs your function once, so it sees one path. If your code\n",
+    "branches on the data, the formula you get is the formula for the\n",
+    "branch your input happened to take. This notebook shows the danger,\n",
+    "and the fix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dda6c7d8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T03:28:02.798437Z",
+     "iopub.status.busy": "2026-09-07T03:28:02.798261Z",
+     "iopub.status.idle": "2026-09-07T03:28:03.291978Z",
+     "shell.execute_reply": "2026-09-07T03:28:03.291205Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "import numpy as np\n",
+    "import sympy\n",
+    "from skverify.testing import check_formula\n",
+    "from skverify.explore import explore\n",
+    "\n",
+    "v = sympy.IndexedBase(\"v\")\n",
+    "i = sympy.Symbol(\"i\", integer=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1132bee5",
+   "metadata": {},
+   "source": [
+    "## The danger\n",
+    "\n",
+    "Here is a function with two branches, and a claim about it that is\n",
+    "half right. On inputs with a positive sum it doubles. On the rest it\n",
+    "triples. Our spec says it always doubles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "429201ee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T03:28:03.295886Z",
+     "iopub.status.busy": "2026-09-07T03:28:03.295651Z",
+     "iopub.status.idle": "2026-09-07T03:28:03.321625Z",
+     "shell.execute_reply": "2026-09-07T03:28:03.320736Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "verdict: exact (at shape (2,))\n",
+      "  2/2 entries agree\n"
+     ]
+    }
+   ],
+   "source": [
+    "def f(x):\n",
+    "    if x.sum() > 0:\n",
+    "        return x * 2.0\n",
+    "    return x * 3.0\n",
+    "\n",
+    "x = sympy.IndexedBase(\"x\")\n",
+    "verdict = check_formula(f, (np.array([1.0, 2.0]),), 2 * x[i], indices=(i,))\n",
+    "print(verdict.message())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "404f2800",
+   "metadata": {},
+   "source": [
+    "The check passes, and it is not lying: on the path where the sum is\n",
+    "positive, the code really does compute 2x. The message says which\n",
+    "path. But our test input had a positive sum, so the other branch was\n",
+    "never looked at, and the spec is wrong there. Every test suite in the\n",
+    "world has this blind spot: you check the inputs you thought of."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ae0c22b",
+   "metadata": {},
+   "source": [
+    "## The fix\n",
+    "\n",
+    "`explore=True` closes it. The trace records the branch condition\n",
+    "(the sum is positive). The explorer negates it and asks the Z3\n",
+    "solver for an input on the other side. The solver produces one, the\n",
+    "function runs again on that input, and the spec is checked on the\n",
+    "second branch too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fc19026d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T03:28:03.323522Z",
+     "iopub.status.busy": "2026-09-07T03:28:03.323298Z",
+     "iopub.status.idle": "2026-09-07T03:28:03.434857Z",
+     "shell.execute_reply": "2026-09-07T03:28:03.434011Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "verdict: differs (at shape (2,))\n",
+      "  your spec:  2*x[0]\n",
+      "  the code:   3.0*x[0]\n",
+      "  counterexample:\n",
+      "      x[0] = 21/10\n",
+      "      spec value = 4.2\n",
+      "      code value = 6.300000000000001\n",
+      "  first disagreement at entry (0,)\n",
+      "  on the path where: Sum(x[j], (j, 0, 1)) <= 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "verdict = check_formula(f, (np.array([1.0, 2.0]),), 2 * x[i],\n",
+    "                        indices=(i,), explore=True)\n",
+    "print(verdict.message())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dff9386f",
+   "metadata": {},
+   "source": [
+    "Caught. The spec fails on the branch where the sum is not positive,\n",
+    "and the message names that branch. No amount of staring at our\n",
+    "original test input would have found this, because the bug is not at\n",
+    "any input we ran. It is on a path we never took."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2963573d",
+   "metadata": {},
+   "source": [
+    "## What exploration looks like\n",
+    "\n",
+    "`explore` on its own shows the map: which paths exist, which were\n",
+    "visited, and what happened to the regions in between. Three\n",
+    "outcomes are possible for a region, and all three are stated, never\n",
+    "guessed:\n",
+    "\n",
+    "* visited: the solver produced an input, the function ran on it\n",
+    "* proven infeasible: the solver showed no input reaches it\n",
+    "* undecided: neither, named in the result, and coverage is not claimed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1cb1d7e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T03:28:03.437143Z",
+     "iopub.status.busy": "2026-09-07T03:28:03.436905Z",
+     "iopub.status.idle": "2026-09-07T03:28:03.535155Z",
+     "shell.execute_reply": "2026-09-07T03:28:03.534181Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 path(s) explored, 1 region(s) proven infeasible -- coverage proven\n",
+      "  path: (x[0] <= 1.0, x[0] > 0.0)\n",
+      "  path: (x[0] <= 0.0, x[0] <= 1.0)\n",
+      "  path: (x[0] > 1.0,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def clip_like(x):\n",
+    "    if x[0] > 1.0:\n",
+    "        return x * 2.0\n",
+    "    if x[0] > 0.0:\n",
+    "        return x + 1.0\n",
+    "    return x\n",
+    "\n",
+    "r = explore(clip_like, (np.array([1.0, 2.0]),))\n",
+    "print(r.summary())\n",
+    "for p in r.paths:\n",
+    "    print(\"  path:\", p.condition)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5fc25d4",
+   "metadata": {},
+   "source": [
+    "Three branches, three paths, and the fourth combination (x above 1\n",
+    "and below 0 at the same time) was proven impossible rather than\n",
+    "silently skipped.\n",
+    "\n",
+    "A subtler case: `np.sinc` has a special value at zero. That branch\n",
+    "is a single point, so no test input ever lands on it by luck. The\n",
+    "solver computes it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a78a9f54",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T03:28:03.537610Z",
+     "iopub.status.busy": "2026-09-07T03:28:03.537421Z",
+     "iopub.status.idle": "2026-09-07T03:28:03.637098Z",
+     "shell.execute_reply": "2026-09-07T03:28:03.636142Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 path(s) explored -- coverage proven"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "paths found: 8\n"
+     ]
+    }
+   ],
+   "source": [
+    "r = explore(lambda a: np.sinc(a), (np.array([0.7, -1.2, 2.5]),))\n",
+    "print(r.summary())\n",
+    "print(\"paths found:\", len(r.paths))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc42ab4d",
+   "metadata": {},
+   "source": [
+    "Eight paths: every combination of which entries are zero. The\n",
+    "degenerate cases that break numerical code in practice are exactly\n",
+    "these measure-zero branches, and they are the ones random testing\n",
+    "can never reach.\n",
+    "\n",
+    "## The honest edges\n",
+    "\n",
+    "Two limits, stated plainly. First, the proof is for the traced input\n",
+    "shape: all values of a length-2 array is a theorem, length 3 is a\n",
+    "new run. Second, functions whose branch count explodes (sorting 6\n",
+    "elements has hundreds of orderings) hit a path budget, and the\n",
+    "result says \"stopped at the cap\" instead of claiming coverage.\n",
+    "\n",
+    "Measured over every public numpy function the tracer lifts, 274 of\n",
+    "293 get coverage proven, and the rest say exactly which of the two\n",
+    "limits they hit. The boards in `coverage/` regenerate the number."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.26",
     "sympy>=1.12",
+    "z3-solver>=4.12",
 ]
 dynamic = ["version"]
 

--- a/skverify/explore.py
+++ b/skverify/explore.py
@@ -1,0 +1,275 @@
+"""Explore every branch a function has, and say so honestly.
+
+One trace covers one path: the verdict "matches" holds on that path
+only. explore() closes the gap the way DART (Godefroid, Klarlund and
+Sen, 2005) does: take the branch conditions the trace recorded, negate
+one, find an input on the other side, trace again, repeat. When every
+unexplored side is either visited or PROVEN infeasible, coverage is a
+theorem, not a sample.
+
+Witnesses come from constrained sampling (draw exact rationals, force
+equalities constructively, reject points off the target region).
+Infeasibility comes from sympy's LRA solver, used only for
+refutations: a reported model is never trusted (the solver has a
+known spurious-model mode), but False is a proof. Anything neither
+witnessed nor refuted is an UNDECIDED region, named in the result --
+covers() is then False and the caller knows exactly why.
+"""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import sympy
+
+from .api import to_sympy
+
+MAX_PATHS = 32
+MAX_TRIES = 512
+
+
+@dataclass
+class Path:
+    args: tuple
+    condition: tuple  # ordered guard atoms
+    out: object = None
+
+
+@dataclass
+class Exploration:
+    paths: list = field(default_factory=list)
+    infeasible: list = field(default_factory=list)  # refuted regions
+    undecided: list = field(default_factory=list)   # neither witnessed nor refuted
+    refusals: list = field(default_factory=list)    # paths the tracer refused
+
+    @property
+    def complete(self):
+        """True when the visited paths provably cover every input of
+        this shape: no undecided regions, no refused paths, and every
+        other region refuted."""
+        return not self.undecided and not self.refusals and bool(self.paths)
+
+    def summary(self):
+        parts = [f"{len(self.paths)} path(s) explored"]
+        if self.infeasible:
+            parts.append(f"{len(self.infeasible)} region(s) proven infeasible")
+        if self.undecided:
+            parts.append(f"{len(self.undecided)} region(s) UNDECIDED")
+        if self.refusals:
+            parts.append(f"{len(self.refusals)} path(s) refused by the tracer")
+        head = ", ".join(parts)
+        return head + (" -- coverage proven" if self.complete else
+                       " -- coverage NOT proven")
+
+
+def _atoms_of(pre):
+    if pre in (sympy.true, True):
+        return ()
+    if isinstance(pre, sympy.And):
+        return tuple(pre.args)
+    return (pre,)
+
+
+def _negate(atom):
+    n = getattr(atom, "negated", None)
+    return n if n is not None else sympy.Not(atom)
+
+
+def _slots_of(atoms):
+    """Concrete input slots a witness must assign: Indexed with integer
+    indices, plus plain (non-axis) Symbols."""
+    slots, syms = set(), set()
+    axis_names = set("ijklm")
+    for a in atoms:
+        if not isinstance(a, sympy.Basic):
+            continue
+        for e in a.atoms(sympy.Indexed):
+            if all(ix.is_Integer for ix in e.indices):
+                slots.add(e)
+        for s in a.free_symbols:
+            if isinstance(s, sympy.Symbol) and s.name not in axis_names \
+                    and not isinstance(s, sympy.tensor.indexed.IndexedBase):
+                syms.add(s)
+    return sorted(slots, key=str), sorted(syms, key=str)
+
+
+def _holds(atom, subs):
+    try:
+        v = atom.xreplace(subs)
+        if v in (sympy.true, True):
+            return True
+        if v in (sympy.false, False):
+            return False
+        return bool(sympy.simplify(v))
+    except Exception:
+        return False
+
+
+def _unrolled(target):
+    """Guards can bind reduction dummies (Sum(v[j], ...) > 0); doit()
+    turns them into concrete-slot expressions a witness can assign."""
+    out = []
+    for a in target:
+        try:
+            out.append(a.doit())
+        except Exception:
+            out.append(a)
+    return out
+
+
+def _witness(target, rng):
+    """An exact rational assignment satisfying every atom in target,
+    or None. Equalities assign constructively (Eq(a, b) forces the
+    slots equal); inequalities go by rejection sampling."""
+    target = _unrolled(target)
+    eqs = [a for a in target if isinstance(a, sympy.Eq)]
+    rest = [a for a in target if not isinstance(a, sympy.Eq)]
+    slots, syms = _slots_of(target)
+    for _ in range(MAX_TRIES):
+        subs = {
+            e: sympy.Rational(int(rng.integers(-400, 400)), 100)
+            for e in slots
+        }
+        subs.update({
+            s: sympy.Rational(int(rng.integers(-400, 400)), 100)
+            for s in syms
+        })
+        ok = True
+        for eq in eqs:
+            l, r = eq.lhs, eq.rhs
+            if l in subs and not (isinstance(r, sympy.Basic) and r.free_symbols):
+                subs[l] = sympy.nsimplify(r)
+            elif r in subs and not (isinstance(l, sympy.Basic) and l.free_symbols):
+                subs[r] = sympy.nsimplify(l)
+            elif l in subs and r in subs:
+                subs[l] = subs[r]
+            elif not _holds(eq, subs):
+                ok = False
+                break
+        if not ok:
+            continue
+        if all(_holds(a, subs) for a in eqs + rest):
+            return subs
+    return None
+
+
+def _refuted(target):
+    """True only when sympy PROVES the region empty. A model answer is
+    not trusted (spurious-model mode); False is a proof. LRA does not
+    treat Indexed as theory variables, so each distinct slot maps to a
+    fresh real Symbol first -- sound for refutation (any real solution
+    over slots is one over the symbols and vice versa)."""
+    try:
+        from sympy.logic.inference import satisfiable
+
+        target = _unrolled(target)
+        slots = {
+            e
+            for a in target
+            if isinstance(a, sympy.Basic)
+            for e in a.atoms(sympy.Indexed)
+        }
+        mapping = {
+            e: sympy.Dummy(f"s{k}", real=True)
+            for k, e in enumerate(sorted(slots, key=str))
+        }
+        expr = sympy.And(*[
+            a.xreplace(mapping) if isinstance(a, sympy.Basic) else a
+            for a in target
+        ])
+        # LRA takes rationals only; every binary float IS one exactly
+        floats = {
+            f: sympy.Rational(f) for f in expr.atoms(sympy.Float)
+        }
+        if floats:
+            expr = expr.xreplace(floats)
+        return satisfiable(expr, use_lra_theory=True) is False
+    except Exception:
+        return False
+
+
+def _rebuild_args(base_args, subs):
+    """Concrete arguments realizing a witness: copies of the originals
+    with every assigned slot written in."""
+    out = [np.array(a, dtype=float, copy=True) if isinstance(a, np.ndarray)
+           else a for a in base_args]
+    names = {}
+    for k, a in enumerate(out):
+        # positional parameter names were used to wrap: recover by order
+        names[k] = a
+    by_name = {}
+    for e, val in subs.items():
+        if isinstance(e, sympy.Indexed):
+            by_name.setdefault(str(e.base.label), []).append(
+                (tuple(int(ix) for ix in e.indices), float(val))
+            )
+    # match array args to bases by shape-compatible writes, in order
+    import inspect as _unused  # names come from the trace wrap order
+    bases = list(by_name)
+    ai = 0
+    for base in bases:
+        while ai < len(out) and not isinstance(out[ai], np.ndarray):
+            ai += 1
+        if ai >= len(out):
+            break
+        for idx, val in by_name[base]:
+            try:
+                out[ai][idx] = val
+            except Exception:
+                pass
+        ai += 1
+    for e, val in subs.items():
+        if isinstance(e, sympy.Symbol):
+            for k, a in enumerate(out):
+                if not isinstance(a, np.ndarray):
+                    out[k] = float(val)
+                    break
+    return tuple(out)
+
+
+def explore(fn, args, max_paths=MAX_PATHS, seed=0):
+    """Trace ``fn`` on ``args``, then keep finding inputs that take
+    other branches until every branch is visited or proven infeasible.
+
+    Returns an :class:`Exploration`; ``.complete`` is the covers()
+    claim: the visited paths provably cover every input of this shape.
+    """
+    rng = np.random.default_rng(seed)
+    result = Exploration()
+    seen = set()
+    worklist = [tuple(args)]
+    while worklist and len(result.paths) < max_paths:
+        cur = worklist.pop()
+        try:
+            out = to_sympy(fn, *[
+                a.copy() if isinstance(a, np.ndarray) else a for a in cur
+            ])
+        except NotImplementedError as e:
+            result.refusals.append(str(e)[:120])
+            continue
+        atoms = _atoms_of(getattr(out, "preconditions", sympy.true))
+        sig = frozenset(atoms)
+        if sig in seen:
+            continue
+        seen.add(sig)
+        result.paths.append(Path(args=cur, condition=atoms, out=out))
+        # DART step: negate each guard with the earlier ones held
+        for k in range(len(atoms)):
+            target = list(atoms[:k]) + [_negate(atoms[k])]
+            tsig = frozenset(target)
+            if tsig in seen:
+                continue
+            wit = _witness(target, rng)
+            if wit is not None:
+                worklist.append(_rebuild_args(cur, wit))
+            elif _refuted(target):
+                result.infeasible.append(sympy.And(*target))
+                seen.add(tsig)
+            else:
+                result.undecided.append(sympy.And(*target))
+                seen.add(tsig)
+    return result
+
+
+def covers(fn, args, **kw):
+    """The one-word form: does exploration provably reach every branch?"""
+    return explore(fn, args, **kw).complete

--- a/skverify/explore.py
+++ b/skverify/explore.py
@@ -125,13 +125,38 @@ def _unrolled(target):
     return out
 
 
+def _forced_ties(atoms):
+    """Pairs bounded from both sides are equalities in disguise:
+    a >= b together with a <= b is a tie region, which rejection
+    sampling hits with probability zero. Detect them so the draw can
+    assign the pair EQUAL constructively (sort and median tie paths,
+    variance-zero branches)."""
+    seen = {}
+    ties = []
+    for a in atoms:
+        if not isinstance(a, (sympy.Le, sympy.Ge)):
+            continue
+        lo, hi = (a.lhs, a.rhs) if isinstance(a, sympy.Le) else (a.rhs, a.lhs)
+        key = tuple(sorted((lo, hi), key=sympy.default_sort_key))
+        direction = "le" if (lo, hi) == key else "ge"
+        prev = seen.get(key)
+        if prev is not None and prev != direction:
+            ties.append(key)
+        seen[key] = direction
+    return ties
+
+
 def _witness(target, rng):
     """An exact rational assignment satisfying every atom in target,
     or None. Equalities assign constructively (Eq(a, b) forces the
-    slots equal); inequalities go by rejection sampling."""
+    slots equal, opposite inequalities force ties); plain inequalities
+    go by rejection sampling. The last quarter of the budget draws
+    ALL-EQUAL per array (one value for every slot of a base): the
+    constructive route into variance-zero and all-tied regions."""
     target = _unrolled(target)
     eqs = [a for a in target if isinstance(a, sympy.Eq)]
     rest = [a for a in target if not isinstance(a, sympy.Eq)]
+    ties = _forced_ties(rest)
     slots, syms = _slots_of(target)
     for trial in range(MAX_TRIES):
         # escalate the range every quarter of the budget: a guard like
@@ -145,6 +170,21 @@ def _witness(target, rng):
             s: sympy.Rational(int(rng.integers(-span, span)), 100)
             for s in syms
         })
+        if trial > 3 * MAX_TRIES // 4 and slots:
+            # all-equal mode: one value per array base
+            per_base = {}
+            for e in slots:
+                base = str(e.base.label)
+                if base not in per_base:
+                    per_base[base] = subs[e]
+                subs[e] = per_base[base]
+        for x, y in ties:
+            if x in subs and y in subs:
+                subs[x] = subs[y]
+            elif x in subs and not (
+                isinstance(y, sympy.Basic) and y.free_symbols
+            ):
+                subs[x] = sympy.nsimplify(y)
         ok = True
         for eq in eqs:
             l, r = eq.lhs, eq.rhs

--- a/skverify/explore.py
+++ b/skverify/explore.py
@@ -7,19 +7,21 @@ one, find an input on the other side, trace again, repeat. When every
 unexplored side is either visited or PROVEN infeasible, coverage is a
 theorem, not a sample.
 
-Witnesses come from constrained sampling (draw exact rationals, force
-equalities constructively, reject points off the target region).
-Infeasibility comes from sympy's LRA solver, used only for
-refutations: a reported model is never trusted (the solver has a
-known spurious-model mode), but False is a proof. Anything neither
-witnessed nor refuted is an UNDECIDED region, named in the result --
-covers() is then False and the caller knows exactly why.
+Witnesses and refutations both come from Z3 (a required dependency):
+a model gives the input for an unexplored branch as exact rationals,
+unsat is the proof a region is empty. Models are still VERIFIED by
+substitution before use -- the solver proposes, the check disposes.
+Guards outside Z3's polynomial fragment (exp, log) fall back to
+constrained exact-rational sampling. Anything neither witnessed nor
+refuted is an UNDECIDED region, named in the result -- covers() is
+then False and the caller knows exactly why.
 """
 
 from dataclasses import dataclass, field
 
 import numpy as np
 import sympy
+import z3
 
 from .api import to_sympy
 
@@ -86,7 +88,7 @@ def _negate(atom):
 def _slots_of(atoms):
     """Concrete input slots a witness must assign: Indexed with integer
     indices, plus plain (non-axis) Symbols."""
-    slots, syms = set(), set()
+    slots, syms, labels = set(), set(), set()
     axis_names = set("ijklm")
     for a in atoms:
         if not isinstance(a, sympy.Basic):
@@ -94,8 +96,16 @@ def _slots_of(atoms):
         for e in a.atoms(sympy.Indexed):
             if all(ix.is_Integer for ix in e.indices):
                 slots.add(e)
+            labels.add(e.base.label)
+    for a in atoms:
+        if not isinstance(a, sympy.Basic):
+            continue
         for s in a.free_symbols:
+            # an Indexed's free_symbols include its base LABEL, which
+            # is not an assignable slot -- witnessing it would shadow
+            # the real a0[k] slots
             if isinstance(s, sympy.Symbol) and s.name not in axis_names \
+                    and s not in labels \
                     and not isinstance(s, sympy.tensor.indexed.IndexedBase):
                 syms.add(s)
     return sorted(slots, key=str), sorted(syms, key=str)
@@ -194,9 +204,29 @@ def _witness(target, rng):
                 subs[r] = sympy.nsimplify(l)
             elif l in subs and r in subs:
                 subs[l] = subs[r]
-            elif not _holds(eq, subs):
-                ok = False
-                break
+            else:
+                # one unknown slot: SOLVE the equality instead of
+                # hoping to sample it (sinc's Eq(pi*x, 0) branch)
+                free = [e for e in subs if isinstance(e, sympy.Basic)
+                        and (l - r).has(e)]
+                solved = False
+                if len(free) >= 1 and trial < 8:
+                    tgt = free[0]
+                    others = {e: v for e, v in subs.items() if e != tgt}
+                    try:
+                        # solve() rejects Indexed unknowns: go through
+                        # a Dummy stand-in
+                        d = sympy.Dummy("w", real=True)
+                        expr = (l - r).xreplace(others).xreplace({tgt: d})
+                        sol = sympy.solve(expr, d, rational=True)
+                        if sol:
+                            subs[tgt] = sympy.nsimplify(sol[0])
+                            solved = True
+                    except Exception:
+                        pass
+                if not solved and not _holds(eq, subs):
+                    ok = False
+                    break
         if not ok:
             continue
         if all(_holds(a, subs) for a in eqs + rest):
@@ -205,36 +235,23 @@ def _witness(target, rng):
 
 
 def _refuted(target):
-    """True only when sympy PROVES the region empty. A model answer is
-    not trusted (spurious-model mode); False is a proof. LRA does not
-    treat Indexed as theory variables, so each distinct slot maps to a
-    fresh real Symbol first -- sound for refutation (any real solution
-    over slots is one over the symbols and vice versa)."""
+    """True only when Z3 PROVES the region empty (unsat over the
+    reals, nlsat decides the polynomial fragment). Atoms outside the
+    fragment make refutation impossible here: the region stays
+    undecided rather than guessed."""
     try:
-        from sympy.logic.inference import satisfiable
-
         target = _unrolled(target)
-        slots = {
-            e
-            for a in target
-            if isinstance(a, sympy.Basic)
-            for e in a.atoms(sympy.Indexed)
-        }
-        mapping = {
-            e: sympy.Dummy(f"s{k}", real=True)
-            for k, e in enumerate(sorted(slots, key=str))
-        }
-        expr = sympy.And(*[
-            a.xreplace(mapping) if isinstance(a, sympy.Basic) else a
-            for a in target
-        ])
-        # LRA takes rationals only; every binary float IS one exactly
-        floats = {
-            f: sympy.Rational(f) for f in expr.atoms(sympy.Float)
-        }
-        if floats:
-            expr = expr.xreplace(floats)
-        return satisfiable(expr, use_lra_theory=True) is False
+        varmap = {}
+        constraints = []
+        for a in target:
+            c = _to_z3(a, z3, varmap)
+            if c is None:
+                return False  # outside the fragment: cannot refute
+            constraints.append(c)
+        solver = z3.Solver()
+        solver.set("timeout", 1000)
+        solver.add(*constraints)
+        return solver.check() == z3.unsat
     except Exception:
         return False
 
@@ -278,19 +295,116 @@ def _rebuild_args(fn, base_args, subs):
     return tuple(out)
 
 
-def explore(fn, args, max_paths=MAX_PATHS, seed=0):
+
+
+def _to_z3(expr, z3, varmap):
+    """sympy relational/arithmetic -> z3, real semantics. Returns None
+    for anything outside the polynomial fragment (exp, log, ...)."""
+    import sympy as sp
+
+    def conv(e):
+        if isinstance(e, sp.Indexed) or isinstance(e, sp.Symbol):
+            if e not in varmap:
+                varmap[e] = z3.Real(f"v{len(varmap)}")
+            return varmap[e]
+        if isinstance(e, sp.Integer):
+            return z3.RealVal(int(e))
+        if isinstance(e, sp.Rational):
+            return z3.RealVal(f"{e.p}/{e.q}")
+        if isinstance(e, sp.Float):
+            r = sp.Rational(e)
+            return z3.RealVal(f"{r.p}/{r.q}")
+        if isinstance(e, sp.Add):
+            parts = [conv(a) for a in e.args]
+            if any(p is None for p in parts):
+                return None
+            out = parts[0]
+            for p in parts[1:]:
+                out = out + p
+            return out
+        if isinstance(e, sp.Mul):
+            parts = [conv(a) for a in e.args]
+            if any(p is None for p in parts):
+                return None
+            out = parts[0]
+            for p in parts[1:]:
+                out = out * p
+            return out
+        if isinstance(e, sp.Pow):
+            base = conv(e.base)
+            if base is None or not e.exp.is_Integer or e.exp < 0:
+                return None
+            out = base
+            for _ in range(int(e.exp) - 1):
+                out = out * base
+            return out
+        if isinstance(e, sp.Abs):
+            inner = conv(e.args[0])
+            if inner is None:
+                return None
+            return z3.If(inner >= 0, inner, -inner)
+        return None
+
+    rel = {sp.Gt: lambda a, b: a > b, sp.Ge: lambda a, b: a >= b,
+           sp.Lt: lambda a, b: a < b, sp.Le: lambda a, b: a <= b,
+           sp.Eq: lambda a, b: a == b, sp.Ne: lambda a, b: a != b}
+    for cls, mk in rel.items():
+        if isinstance(expr, cls):
+            l, r = conv(expr.lhs), conv(expr.rhs)
+            if l is None or r is None:
+                return None
+            return mk(l, r)
+    return None
+
+
+def _witness_z3(target):
+    """Solver-generated witness: exact rationals from a z3 model over
+    the polynomial fragment (nlsat decides it). Returns None when an
+    atom falls outside the fragment or the region is unsat. Every
+    returned point is still VERIFIED by substitution by the caller:
+    the model is a candidate, never an oracle."""
+    target = _unrolled(target)
+    varmap = {}
+    constraints = []
+    for a in target:
+        c = _to_z3(a, z3, varmap)
+        if c is None:
+            return None  # outside the fragment: fall back to sampling
+        constraints.append(c)
+    solver = z3.Solver()
+    solver.set("timeout", 1000)
+    solver.add(*constraints)
+    if solver.check() != z3.sat:
+        return None
+    model = solver.model()
+    subs = {}
+    for sym, var in varmap.items():
+        val = model.eval(var, model_completion=True)
+        # exact rational out of z3 (decimals would round)
+        frac = val.as_fraction()
+        subs[sym] = sympy.Rational(frac.numerator, frac.denominator)
+    return subs
+
+
+def explore(fn, args, max_paths=MAX_PATHS, seed=0, time_budget=120.0):
     """Trace ``fn`` on ``args``, then keep finding inputs that take
     other branches until every branch is visited or proven infeasible.
 
     Returns an :class:`Exploration`; ``.complete`` is the covers()
     claim: the visited paths provably cover every input of this shape.
+    ``time_budget`` (seconds of wall clock) ends exploration honestly:
+    past it the result is marked capped and completeness is never
+    claimed.
     """
+    import time as _time
+
+    deadline = _time.monotonic() + time_budget
     rng = np.random.default_rng(seed)
     result = Exploration()
     seen = set()
     worklist = [tuple(args)]
     while worklist:
-        if len(result.paths) >= max_paths:
+        if len(result.paths) >= max_paths or _time.monotonic() > deadline:
             result.capped = True
             break
         cur = worklist.pop()
@@ -309,11 +423,20 @@ def explore(fn, args, max_paths=MAX_PATHS, seed=0):
         result.paths.append(Path(args=cur, condition=atoms, out=out))
         # DART step: negate each guard with the earlier ones held
         for k in range(len(atoms)):
+            if _time.monotonic() > deadline:
+                result.capped = True
+                break
             target = list(atoms[:k]) + [_negate(atoms[k])]
             tsig = frozenset(target)
             if tsig in seen:
                 continue
-            wit = _witness(target, rng)
+            wit = _witness_z3(target)
+            if wit is not None and not all(
+                _holds(a, wit) for a in _unrolled(target)
+            ):
+                wit = None  # model failed verification: never trust it
+            if wit is None:
+                wit = _witness(target, rng)
             if wit is not None:
                 worklist.append(_rebuild_args(fn, cur, wit))
             elif _refuted(target):

--- a/skverify/explore.py
+++ b/skverify/explore.py
@@ -40,13 +40,20 @@ class Exploration:
     infeasible: list = field(default_factory=list)  # refuted regions
     undecided: list = field(default_factory=list)   # neither witnessed nor refuted
     refusals: list = field(default_factory=list)    # paths the tracer refused
+    capped: bool = False  # stopped at max_paths with work remaining
 
     @property
     def complete(self):
         """True when the visited paths provably cover every input of
-        this shape: no undecided regions, no refused paths, and every
-        other region refuted."""
-        return not self.undecided and not self.refusals and bool(self.paths)
+        this shape: no undecided regions, no refused paths, nothing
+        left unexplored at the path cap, and every other region
+        refuted."""
+        return (
+            not self.undecided
+            and not self.refusals
+            and not self.capped
+            and bool(self.paths)
+        )
 
     def summary(self):
         parts = [f"{len(self.paths)} path(s) explored"]
@@ -56,6 +63,8 @@ class Exploration:
             parts.append(f"{len(self.undecided)} region(s) UNDECIDED")
         if self.refusals:
             parts.append(f"{len(self.refusals)} path(s) refused by the tracer")
+        if self.capped:
+            parts.append("stopped at the path cap with work remaining")
         head = ", ".join(parts)
         return head + (" -- coverage proven" if self.complete else
                        " -- coverage NOT proven")
@@ -124,13 +133,16 @@ def _witness(target, rng):
     eqs = [a for a in target if isinstance(a, sympy.Eq)]
     rest = [a for a in target if not isinstance(a, sympy.Eq)]
     slots, syms = _slots_of(target)
-    for _ in range(MAX_TRIES):
+    for trial in range(MAX_TRIES):
+        # escalate the range every quarter of the budget: a guard like
+        # v[0] > 100 lives far outside the default window
+        span = 400 * 10 ** (4 * trial // MAX_TRIES)
         subs = {
-            e: sympy.Rational(int(rng.integers(-400, 400)), 100)
+            e: sympy.Rational(int(rng.integers(-span, span)), 100)
             for e in slots
         }
         subs.update({
-            s: sympy.Rational(int(rng.integers(-400, 400)), 100)
+            s: sympy.Rational(int(rng.integers(-span, span)), 100)
             for s in syms
         })
         ok = True
@@ -187,42 +199,42 @@ def _refuted(target):
         return False
 
 
-def _rebuild_args(base_args, subs):
+def _param_names(fn, n):
+    """Positional parameter names, the same way the tracer names
+    wrapped arguments; falls back to arg0.. when introspection
+    fails (builtins, some callables)."""
+    import inspect
+
+    try:
+        params = list(inspect.signature(fn).parameters)
+        if len(params) >= n:
+            return params[:n]
+    except (TypeError, ValueError):
+        pass
+    return [f"arg{k}" for k in range(n)]
+
+
+def _rebuild_args(fn, base_args, subs):
     """Concrete arguments realizing a witness: copies of the originals
-    with every assigned slot written in."""
+    with every assigned slot written in, matched to parameters BY NAME
+    (guard bases are named after the function's parameters)."""
     out = [np.array(a, dtype=float, copy=True) if isinstance(a, np.ndarray)
            else a for a in base_args]
-    names = {}
-    for k, a in enumerate(out):
-        # positional parameter names were used to wrap: recover by order
-        names[k] = a
-    by_name = {}
+    names = _param_names(fn, len(out))
+    position = {name: k for k, name in enumerate(names)}
     for e, val in subs.items():
         if isinstance(e, sympy.Indexed):
-            by_name.setdefault(str(e.base.label), []).append(
-                (tuple(int(ix) for ix in e.indices), float(val))
-            )
-    # match array args to bases by shape-compatible writes, in order
-    import inspect as _unused  # names come from the trace wrap order
-    bases = list(by_name)
-    ai = 0
-    for base in bases:
-        while ai < len(out) and not isinstance(out[ai], np.ndarray):
-            ai += 1
-        if ai >= len(out):
-            break
-        for idx, val in by_name[base]:
-            try:
-                out[ai][idx] = val
-            except Exception:
-                pass
-        ai += 1
-    for e, val in subs.items():
-        if isinstance(e, sympy.Symbol):
-            for k, a in enumerate(out):
-                if not isinstance(a, np.ndarray):
-                    out[k] = float(val)
-                    break
+            k = position.get(str(e.base.label))
+            if k is not None and isinstance(out[k], np.ndarray):
+                idx = tuple(int(ix) for ix in e.indices)
+                try:
+                    out[k][idx] = float(val)
+                except (IndexError, ValueError):
+                    pass
+        elif isinstance(e, sympy.Symbol):
+            k = position.get(e.name)
+            if k is not None and not isinstance(out[k], np.ndarray):
+                out[k] = float(val)
     return tuple(out)
 
 
@@ -237,7 +249,10 @@ def explore(fn, args, max_paths=MAX_PATHS, seed=0):
     result = Exploration()
     seen = set()
     worklist = [tuple(args)]
-    while worklist and len(result.paths) < max_paths:
+    while worklist:
+        if len(result.paths) >= max_paths:
+            result.capped = True
+            break
         cur = worklist.pop()
         try:
             out = to_sympy(fn, *[
@@ -260,7 +275,7 @@ def explore(fn, args, max_paths=MAX_PATHS, seed=0):
                 continue
             wit = _witness(target, rng)
             if wit is not None:
-                worklist.append(_rebuild_args(cur, wit))
+                worklist.append(_rebuild_args(fn, cur, wit))
             elif _refuted(target):
                 result.infeasible.append(sympy.And(*target))
                 seen.add(tsig)

--- a/skverify/testing.py
+++ b/skverify/testing.py
@@ -454,8 +454,16 @@ def _entry_equal(t, s, entry, samples, assume=(), guards=()):
         },
         key=str,
     )
+    labels = {
+        e.base.label
+        for x in (td, sd)
+        for e in x.atoms(sympy.Indexed)
+    }
     syms = sorted(
-        (td - sd).free_symbols - set(sympy.symbols("i j k l m")), key=str
+        (td - sd).free_symbols
+        - set(sympy.symbols("i j k l m"))
+        - labels,  # an Indexed's base label is not an assignable input
+        key=str,
     )
     agree = True
     point = {}

--- a/skverify/testing.py
+++ b/skverify/testing.py
@@ -84,6 +84,13 @@ def check_formula(fn, args, spec, indices=(), assume=(), samples=3,
     samples : int, optional
         Exact rational sample points used when the symbolic
         difference does not vanish (the float-constant tier).
+    explore : bool, optional
+        Check the spec on EVERY reachable branch, not just the one
+        ``args`` takes: branch guards are negated and solved for
+        inputs on the other side (see :func:`skverify.explore.explore`).
+        The verdict then reports coverage: "coverage proven" when
+        every unvisited region was proven infeasible, or an honest
+        qualifier when regions stay undecided.
 
     Returns
     -------

--- a/skverify/testing.py
+++ b/skverify/testing.py
@@ -53,7 +53,8 @@ class Verdict:
         return "\n".join(lines)
 
 
-def check_formula(fn, args, spec, indices=(), assume=(), samples=3):
+def check_formula(fn, args, spec, indices=(), assume=(), samples=3,
+                  explore=False):
     """Trace ``fn`` and compare its formula against ``spec``, per entry.
 
     The spec must come from outside the code -- a paper, a docstring,
@@ -113,6 +114,8 @@ def check_formula(fn, args, spec, indices=(), assume=(), samples=3):
     ...               3 * V[i] + 1, indices=(i,)).tier
     'differs'
     """
+    if explore:
+        return _check_everywhere(fn, args, spec, indices, assume, samples)
     try:
         out = to_sympy(fn, *args)
     except NotImplementedError as e:
@@ -121,6 +124,41 @@ def check_formula(fn, args, spec, indices=(), assume=(), samples=3):
             shape=tuple(np.shape(args[0])),
             detail=f"the tracer refused: {e} (a tracer limit, not a code bug)",
         )
+    return _check_traced(out, spec, indices, assume, samples)
+
+
+def _check_everywhere(fn, args, spec, indices, assume, samples):
+    """The explored form: check the spec on EVERY reachable path.
+    The verdict is the weakest per-path tier; coverage status is part
+    of the detail, so "all paths" is claimed only when proven."""
+    from .explore import explore as _explore
+
+    ex = _explore(fn, args)
+    if not ex.paths:
+        return Verdict(
+            tier="incomplete",
+            shape=tuple(np.shape(args[0])),
+            detail="no path traced: " + "; ".join(ex.refusals[:2]),
+        )
+    order = {"exact": 0, "float-constant": 1, "sampled": 2}
+    worst = None
+    for path in ex.paths:
+        v = _check_traced(path.out, spec, indices, assume, samples)
+        if not v.matches:
+            cond = " & ".join(str(a) for a in path.condition) or "True"
+            v.detail = (v.detail + f"\n  on the path where: {cond}").strip()
+            return v
+        if worst is None or order.get(v.tier, 9) > order.get(worst.tier, 9):
+            worst = v
+    worst.detail = (
+        f"all {len(ex.paths)} path(s): " + worst.detail + "; " + ex.summary()
+    )
+    if not ex.complete:
+        worst.detail += " (matches on explored paths only)"
+    return worst
+
+
+def _check_traced(out, spec, indices, assume, samples):
     shape = tuple(np.shape(out.value))
     bound = {sym: axis_idx(k) for k, sym in enumerate(indices)}
     # traced scalar symbols carry real=True; a user's plain

--- a/tests/testing/test_explore_covers.py
+++ b/tests/testing/test_explore_covers.py
@@ -185,3 +185,13 @@ class TestSharpEdges:
         r = explore(h, (np.array([1.0, 2.0]), 0.1))
         assert len(r.paths) == 2
         assert r.complete
+
+    def test_equality_branch_solved_not_sampled(self):
+        # sinc's removable singularity: the x == 0 branch is a
+        # measure-zero region reachable only by SOLVING the equality
+        def sincish(a0):
+            return np.sinc(a0)
+
+        r = explore(sincish, (np.array([0.7, -1.2, 2.5]),))
+        assert r.complete
+        assert len(r.paths) == 8  # every zero/nonzero combination

--- a/tests/testing/test_explore_covers.py
+++ b/tests/testing/test_explore_covers.py
@@ -132,3 +132,56 @@ class TestCheckEverywhere:
         )
         assert v.matches
         assert "coverage proven" in v.detail
+
+
+class TestSharpEdges:
+    def test_path_cap_never_claims_completeness(self):
+        # 2^5 = 32 sign branches, cap at 4: must say capped, not proven
+        def many(v):
+            out = 0.0
+            for k in range(5):
+                if v[k] > 0:
+                    out = out + v[k]
+                else:
+                    out = out - v[k]
+            return out
+
+        r = explore(many, (np.array([1.0, -1.0, 1.0, -1.0, 1.0]),),
+                    max_paths=4)
+        assert r.capped
+        assert not r.complete
+        assert "path cap" in r.summary()
+
+    def test_far_domain_guard_is_reachable(self):
+        # v[0] > 100 lives outside the default sampling window; the
+        # escalating range must still find a witness
+        def far(v):
+            if v[0] > 100.0:
+                return v * 2.0
+            return v
+
+        r = explore(far, (np.array([1.0, 2.0]),))
+        assert len(r.paths) == 2
+        assert r.complete
+
+    def test_two_array_args_rebuilt_by_name(self):
+        # the branch guard is on the SECOND argument; a positional
+        # rebuild would write the witness into the first
+        def g(u, w):
+            if w[0] > 0:
+                return u + w
+            return u - w
+
+        r = explore(g, (np.array([1.0, 2.0]), np.array([1.0, 2.0])))
+        assert len(r.paths) == 2
+        assert r.complete
+
+    def test_scalar_argument_witnessed(self):
+        def h(v, alpha):
+            if alpha > 0.5:
+                return v * alpha
+            return v
+
+        r = explore(h, (np.array([1.0, 2.0]), 0.1))
+        assert len(r.paths) == 2
+        assert r.complete

--- a/tests/testing/test_explore_covers.py
+++ b/tests/testing/test_explore_covers.py
@@ -1,0 +1,134 @@
+"""explore() visits every branch; covers() is the proof it did.
+
+The case that matters most is the last one: a spec that is correct on
+the path the input happens to take and wrong on the other branch.
+Single-path checking passes it; explore=True catches it.
+"""
+
+import numpy as np
+import pytest
+import sympy
+
+from skverify.explore import covers, explore
+from skverify.testing import check_formula
+
+V = sympy.IndexedBase("v")
+X = sympy.IndexedBase("x")
+i = sympy.Symbol("i", integer=True)
+
+
+def two_branch(v):
+    if v.sum() > 0:
+        return v * 2.0
+    return v * 3.0
+
+
+def three_branch(x):
+    if x[0] > 1.0:
+        return x * 2.0
+    if x[0] > 0.0:
+        return x + 1.0
+    return x
+
+
+def nested_infeasible(v):
+    if v[0] > 2.0:
+        if v[0] < 1.0:  # unreachable under the outer guard
+            return v * 9.0
+        return v * 2.0
+    return v
+
+
+def transcendental_guard(v):
+    if np.exp(v[0]) > 50.0:  # outside the linear fragment
+        return v * 2.0
+    return v
+
+
+class TestExploration:
+    def test_both_branches_found_and_proven(self):
+        r = explore(two_branch, (np.array([1.0, 2.0]),))
+        assert len(r.paths) == 2
+        assert r.complete
+        assert covers(two_branch, (np.array([1.0, 2.0]),))
+
+    def test_three_branches_with_infeasible_combination(self):
+        r = explore(three_branch, (np.array([1.0, 2.0]),))
+        assert len(r.paths) == 3
+        assert r.complete
+        # x <= 0 AND x > 1 was refuted, not silently dropped
+        assert len(r.infeasible) >= 1
+
+    def test_unreachable_branch_proven_infeasible(self):
+        r = explore(nested_infeasible, (np.array([0.0, 0.0]),))
+        assert r.complete
+        conds = [str(p.condition) for p in r.paths]
+        assert not any("9.0" in c for c in conds)  # dead branch never traced
+
+    def test_transcendental_guard_solver_free_witnessing(self):
+        # exp(v0) > 50 is outside LRA, but the SAMPLER can still land
+        # on both sides; completeness holds iff every leftover region
+        # was refuted or witnessed. Whatever the outcome, it must be
+        # stated, never guessed.
+        r = explore(transcendental_guard, (np.array([1.0, 2.0]),))
+        assert len(r.paths) >= 1
+        assert r.complete or r.undecided  # named, either way
+
+    def test_path_conditions_are_disjoint_evidence(self):
+        r = explore(three_branch, (np.array([1.0, 2.0]),))
+        # every explored path carries its own guard set
+        sigs = {frozenset(p.condition) for p in r.paths}
+        assert len(sigs) == len(r.paths)
+
+
+class TestCheckEverywhere:
+    def test_spec_wrong_only_on_the_untraced_branch(self):
+        # THE case this feature exists for. Spec matches the traced
+        # (positive-sum) branch and is wrong on the other one.
+        spec = 2 * V[i]
+
+        v1 = check_formula(
+            two_branch, (np.array([1.0, 2.0]),), spec, indices=(i,)
+        )
+        assert v1.matches  # single-path: passes, honestly qualified
+
+        v2 = check_formula(
+            two_branch, (np.array([1.0, 2.0]),), spec, indices=(i,),
+            explore=True,
+        )
+        assert v2.tier == "differs"
+        assert "on the path where" in v2.detail
+
+    def test_piecewise_spec_matches_everywhere(self):
+        def relu2(v):
+            if v.sum() > 0:
+                return v * 2.0
+            return v * 3.0
+
+        # per-branch specs, checked with each branch's guard assumed:
+        # here one spec that IS the function, via explore on both
+        j = sympy.Dummy("j", integer=True)
+        total = sympy.Sum(V[j], (j, 0, 1))
+        spec = sympy.Piecewise((2 * V[i], total > 0), (3 * V[i], True))
+        v = check_formula(
+            relu2, (np.array([1.0, 2.0]),), spec, indices=(i,),
+            explore=True,
+        )
+        assert v.matches
+        assert "all 2 path(s)" in v.detail
+
+    def test_exact_on_all_paths_reports_coverage(self):
+        def affine_split(x):
+            if x[0] > 0.0:
+                return 3.0 * x + 1.0
+            return 3.0 * x - 1.0
+
+        spec = sympy.Piecewise(
+            (3 * X[i] + 1, X[0] > 0), (3 * X[i] - 1, True)
+        )
+        v = check_formula(
+            affine_split, (np.array([1.0, 2.0]),), spec, indices=(i,),
+            explore=True,
+        )
+        assert v.matches
+        assert "coverage proven" in v.detail


### PR DESCRIPTION
One trace follows one path, so a spec check is honest only about the branch the input took. This adds the loop that visits the rest.

```python
def f(v):
    if v.sum() > 0:
        return v * 2.0
    return v * 3.0

from skverify.explore import explore
r = explore(f, (np.array([1.0, 2.0]),))
r.summary()
# 2 path(s) explored -- coverage proven
```

How: take the branch conditions the trace recorded, negate one, ask Z3 for an input on the other side, trace again, repeat (the DART loop). Every branch region ends in one of three stated outcomes:

- **visited**: Z3 produced a model, converted to exact rationals and VERIFIED by substitution before use (the solver proposes, the check disposes). Guards outside the polynomial fragment (exp, log) fall back to constrained exact-rational sampling with constructive handling of equalities and ties.
- **proven infeasible**: Z3 says unsat, which is a proof. An unreachable branch (`v[0] > 2` then `v[0] < 1`) is pruned with a proof, not skipped silently.
- **undecided**: named in the result, and `covers()` is then False. Never a guess.

Honesty rails: a `max_paths` cap and a wall-clock `time_budget` both end exploration with the result marked capped, and completeness is never claimed with work remaining.

**New required dependency: z3-solver** (pip wheel, no system install). Ratified: random witnessing was a pile of heuristics; the solver computes thin regions (ties, equalities, variance-zero branches) exactly.

The user-facing form is one flag:

```python
check_formula(f, args, spec, indices=(i,), explore=True)
```

A spec correct on the traced branch and wrong on the other one now fails, with the guilty branch printed:

```
verdict: differs (at shape (2,))
  your spec:  2*v[0]
  the code:   3.0*v[0]
  on the path where: Sum(v[j], (j, 0, 1)) <= 0
```

**Measured on the full numpy surface** (coverage/explore_sweep.py, every public np/np.linalg/np.fft callable that lifts, 293 functions): **274 coverage proven (94%), zero undecided regions**, 17 capped (combinatorial ordering families at n=6, honestly reported), 2 path-refused. On the spec-board corpus: 37/38 proven, sort at n=3 yields 12 real paths including ties, sinc's 8 zero-pattern singularity paths all found via solved equalities.

13 tests in tests/testing/test_explore_covers.py; suite 724 green.