### PR TITLE
feat: FFT family as dialect entries, complex formulas

### DIFF
--- a/skverify/maps/numpy.py
+++ b/skverify/maps/numpy.py
@@ -1831,3 +1831,56 @@ FUNCTION_TABLE[np.where] = _where
 FUNCTION_TABLE[np.transpose] = lambda a, axes=None: (
     a.transpose(axes) if isinstance(a, Pair) else np.transpose(a, axes)
 )
+
+
+def _dft_entry(a, name, sign, scale_by_n, out_len_fn, value_fn):
+    """Shared constructor for the FFT family: the discrete Fourier
+    transform IS a closed form at any n,
+
+        X[k] = Sum(a[j] * exp(sign * 2*pi*I*j*k/n), (j, 0, n-1))
+
+    so these are dialect entries, not sealed atoms. Any-n by
+    construction: one Sum, no size cases."""
+    if not isinstance(a, Pair):
+        return value_fn(a)
+    bounds = a._axis_bounds
+    if bounds is None or len(bounds) != 1:
+        raise NotImplementedError(f"{name}: 1-D input only")
+    lo, hi = bounds[0]
+    n = hi - lo
+    value = value_fn(Pair._value_of(a.value))
+    k = axis_idx(0)
+    j = _fresh_dummy(a.formula, 1)
+    body = a.formula.xreplace({k: j}) * sympy.exp(
+        sympy.Integer(sign) * 2 * sympy.pi * sympy.I * j * k
+        / sympy.Integer(n)
+    )
+    formula = _held_sum(body, (j, 0, n - 1))
+    if scale_by_n:
+        formula = formula / sympy.Integer(n)
+    out_n = out_len_fn(n)
+    return Pair(value, formula, ((0, out_n),), steps=(a,))
+
+
+def _fft(a, n=None, axis=-1, norm=None):
+    if n is not None or axis not in (-1, 0) or norm not in (None, "backward"):
+        raise NotImplementedError("fft: n/axis/norm variants not supported")
+    return _dft_entry(a, "fft", -1, False, lambda m: m, np.fft.fft)
+
+
+def _ifft(a, n=None, axis=-1, norm=None):
+    if n is not None or axis not in (-1, 0) or norm not in (None, "backward"):
+        raise NotImplementedError("ifft: n/axis/norm variants not supported")
+    return _dft_entry(a, "ifft", 1, True, lambda m: m, np.fft.ifft)
+
+
+def _rfft(a, n=None, axis=-1, norm=None):
+    if n is not None or axis not in (-1, 0) or norm not in (None, "backward"):
+        raise NotImplementedError("rfft: n/axis/norm variants not supported")
+    # same sum; numpy returns only the first n//2 + 1 entries
+    return _dft_entry(a, "rfft", -1, False, lambda m: m // 2 + 1, np.fft.rfft)
+
+
+FUNCTION_TABLE[np.fft.fft] = _fft
+FUNCTION_TABLE[np.fft.ifft] = _ifft
+FUNCTION_TABLE[np.fft.rfft] = _rfft

--- a/tests/pair/test_fft_dialect.py
+++ b/tests/pair/test_fft_dialect.py
@@ -1,0 +1,94 @@
+"""The FFT family as dialect entries: the DFT is a closed form at any
+n, so fft/ifft/rfft emit Sums instead of sealing as atoms, and
+transform mathematics (round trips, linearity, Parseval) becomes
+checkable instead of opaque."""
+
+import numpy as np
+import pytest
+import sympy
+
+from skverify import to_sympy
+from skverify.helpers import axis_idx
+from skverify.testing import check_formula
+
+V = sympy.IndexedBase("v")
+i = sympy.Symbol("i", integer=True)
+VALS = np.array([0.7, -1.2, 2.5, 0.3])
+N = 4
+
+
+class TestFormulaEqualsValue:
+    @pytest.mark.parametrize("fn,np_fn", [
+        (lambda v: np.fft.fft(v), np.fft.fft),
+        (lambda v: np.fft.rfft(v), np.fft.rfft),
+        (lambda v: np.fft.ifft(v), np.fft.ifft),
+    ], ids=["fft", "rfft", "ifft"])
+    def test_every_entry(self, fn, np_fn):
+        out = to_sympy(fn, VALS.copy())
+        want = np_fn(VALS)
+        subs = {V[k]: VALS[k] for k in range(N)}
+        k0 = axis_idx(0)
+        for kk in range(len(np.atleast_1d(want))):
+            got = complex(sympy.N(out.formula.subs(k0, kk).doit().xreplace(subs)))
+            assert abs(got - complex(want[kk])) < 1e-10, kk
+
+    def test_roundtrip_composes(self):
+        out = to_sympy(lambda v: np.fft.ifft(np.fft.fft(v)), VALS.copy())
+        subs = {V[k]: VALS[k] for k in range(N)}
+        k0 = axis_idx(0)
+        for kk in range(N):
+            got = complex(sympy.N(out.formula.subs(k0, kk).doit().xreplace(subs)))
+            assert abs(got - VALS[kk]) < 1e-10
+
+
+class TestTransformMathematics:
+    def test_linearity_is_exact(self):
+        # fft(a + b) - fft(a) - fft(b) == 0, symbolically
+        U, W = sympy.IndexedBase("u"), sympy.IndexedBase("w")
+
+        def lin(u, w):
+            return (np.fft.fft(u + w) - np.fft.fft(u) - np.fft.fft(w)).real
+
+        v = check_formula(
+            lin, (VALS.copy(), VALS[::-1].copy()),
+            sympy.Integer(0) * U[i] * W[i], indices=(i,), explore=False,
+        )
+        assert v.matches, v.message()
+
+    def test_parseval(self):
+        # sum |X[k]|^2 == n * sum v[j]^2 for real input
+        def power(v):
+            return (np.abs(np.fft.fft(v)) ** 2).sum()
+
+        j = sympy.Dummy("j", integer=True)
+        spec = N * sympy.Sum(V[j] ** 2, (j, 0, N - 1))
+        v = check_formula(power, (VALS.copy(),), spec, explore=False)
+        assert v.matches, v.message()
+
+    def test_dc_component_is_the_sum(self):
+        # X[0] is just the sum of the samples
+        def dc(v):
+            return np.fft.fft(v).real[0]
+
+        j = sympy.Dummy("j", integer=True)
+        v = check_formula(dc, (VALS.copy(),),
+                          sympy.Sum(V[j], (j, 0, N - 1)), explore=False)
+        assert v.matches, v.message()
+
+
+class TestHonestDegradation:
+    """Unsupported variants fall back to the sealed-atom path: closed
+    form where the dialect speaks, disclosed atom elsewhere, never a
+    hard failure for working numpy code."""
+
+    def test_norm_variant_degrades_to_atom(self):
+        out = to_sympy(lambda v: np.fft.fft(v, norm="ortho"), VALS.copy())
+        assert "fft_0" in str(out.formula)
+        assert any("fft" in str(r[0]) for r in out.unchecked
+                   if isinstance(r, tuple))
+
+    def test_2d_degrades_to_atom(self):
+        out = to_sympy(lambda a: np.fft.fft(a), np.arange(4.0).reshape(2, 2))
+        assert "fft_0" in str(out.formula)
+        v = np.asarray(out.value)
+        assert np.allclose(v, np.fft.fft(np.arange(4.0).reshape(2, 2)))


### PR DESCRIPTION
The FFT family was sealed as atoms. unlike eig, the discrete Fourier transform IS a closed form at every size,

```
X[k] = Sum(a[j] * exp(-2*pi*I*j*k/n), (j, 0, n-1))
```

so fft, ifft and rfft are now dialect entries emitting that Sum. One formula, any n, no size cases.

```python
out = to_sympy(lambda v: np.abs(np.fft.fft(v)), np.array([0.7, -1.2, 2.5, 0.3]))
out.formula
# Abs(Sum(exp(-I*pi*i*j/2)*v[j], (j, 0, 3)))
```

The complex value lane turned out to need no surgery: the dtype gates already accept complex, so real/imag/abs/conj/angle of transforms, complex input arrays, and chained round trips all lift with honest formulas.

What becomes checkable (all pinned as tests):

- **Parseval**: `sum |X[k]|^2 == n * sum v[j]^2` matches as a spec
- **linearity**: `fft(a + b) - fft(a) - fft(b)` is exactly zero, symbolically
- the DC component is the sample sum
- `ifft(fft(v))` reproduces v, entry by entry

Unsupported variants (`norm=`, 2-D input) degrade to the old sealed-atom path with disclosure in `.unchecked`, never a hard failure for working numpy code.

9 new tests; suite 746 green; the numpy board's fft entries move from atom-checked to symbolic.