### PR TITLE
TEST: Add test for latex() formula rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ examples/how_skverify_helps.ipynb
 examples/knot_debugging.ipynb
 examples/banded_inverse_lift.ipynb
 examples/.shipped_section_post_merge.ipynb
+.vscode/

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,8 @@
+import numpy as np
+from skverify import to_sympy, latex
+
+def test_latex_returns_a_string():
+    out = to_sympy(lambda x: np.sum(x), np.array([1.0, 2.0, 3.0]))
+    result = latex(out.formula)
+    assert isinstance(result, str)
+    assert len(result) > 0


### PR DESCRIPTION

Description:
Adds a test to verify that `latex()` correctly converts a traced formula into a LaTeX string. Currently, this function lacks any test coverage.

Reference Issue:
Related to #34  (design doc work surfaced that `latex()` and a few other public-facing helpers had no direct tests).


What I did:
Added `tests/test_init.py` with one test, `test_latex_returns_a_string`, which traces a simple `np.sum` call and checks that `latex(out.formula)` returns a non-empty string.


Reason :
`latex()` is likely how users turn a traced result into something they can paste into a paper or README, but it wasn't being tested at all. This is a first, minimal step toward closing that gap — more targeted tests (e.g. `aliases=`, formulas with `Sum`/`Piecewise`) can follow in separate PRs.

AI-Disclosure:
AI is used to understand the required document, which is then manually examined for further refinement.