### PR TITLE
Add formula of test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ examples/how_skverify_helps.ipynb
 examples/knot_debugging.ipynb
 examples/banded_inverse_lift.ipynb
 examples/.shipped_section_post_merge.ipynb
+.vscode/

--- a/tests/coercion/test_formula_of.py
+++ b/tests/coercion/test_formula_of.py
@@ -1,0 +1,11 @@
+import numpy as np
+import sympy
+from skverify.coercion import formula_of
+
+def test_formula_of_discloses_plain_array_as_named_constant_table():
+    plain_array = np.array([1.0, 2.0, 3.0])  # not a Pair, no formula attached
+    result = formula_of(plain_array)
+
+    # it should NOT silently become a made-up formula —
+    # it becomes an indexed symbol we can trace back to a disclosed table
+    assert isinstance(result, sympy.Indexed)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,8 @@
+import numpy as np
+from skverify import to_sympy, latex
+
+def test_latex_returns_a_string():
+    out = to_sympy(lambda x: np.sum(x), np.array([1.0, 2.0, 3.0]))
+    result = latex(out.formula)
+    assert isinstance(result, str)
+    assert len(result) > 0


### PR DESCRIPTION
TEST: Add test for formula_of() disclosed-constant behavior

Description:
Adds a test verifying that formula_of() turns a plain (non-Pair) numeric array into a disclosed, named constant table, rather than raising or silently guessing a formula.

Reference Issue:
Related to #34 (design doc work surfaced that coercion.py's boundary functions had no direct tests, despite the module's own docstring calling it the "highest-risk surface" in the codebase).

What I Did:
Added tests/coercion/test_formula_of.py, which includes a test named test_formula_of_discloses_plain_array_as_named_constant_table. This test passes a plain NumPy array into the formula_of() function, checking that the result is a sympy.Indexed symbol (the disclosed table form) instead of a raw guessed formula.

Reason:
formula_of() is the function responsible for deciding what a raw operand's symbolic meaning is. Getting this wrong would mean a wrong certificate downstream, so it's worth pinning its documented behavior down with a test, even at the simplest possible case.

AI-Disclosure:
AI is utilized to understand the problem better. The initial assumption was that the function `formula_of()` would raise an error on plain arrays. However, after running the test, we discovered the actual documented behavior, which involves using disclosed constant tables. Consequently, the test was corrected to align with this behavior. I reviewed the test, ran it locally, and confirmed that it passes before submitting it.ed to align with this behavior. I reviewed the test, ran it locally, and confirmed that it passes before submitting it.